### PR TITLE
engine: add 'exists' command

### DIFF
--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -17,6 +17,11 @@ pub trait Backend {
 
     async fn echo(&self, content: &[u8]) -> Result<Vec<u8>, Self::Error>;
 
+    async fn exists<T: IntoIterator<Item = U> + Send, U: AsRef<[u8]> + Send>(
+        &self,
+        keys: T,
+    ) -> Result<bool, Self::Error>;
+
     async fn increment(&self, key: &[u8], key_type: Option<KeyType>) -> Result<i64, Self::Error>;
 
     async fn rename(&self, from: &[u8], to: &[u8]) -> Result<Vec<u8>, Self::Error>;

--- a/client/src/backend/server.rs
+++ b/client/src/backend/server.rs
@@ -172,6 +172,24 @@ impl Backend for ServerBackend {
         }
     }
 
+    async fn exists<T: IntoIterator<Item = U> + Send, U: AsRef<[u8]> + Send>(
+        &self,
+        keys: T,
+    ) -> Result<bool> {
+        let args = keys
+            .into_iter()
+            .map(|key| key.as_ref().to_owned())
+            .collect();
+        let req = Request::new(CommandId::Exists, Some(args));
+
+        let value = self.send_and_wait(&req.into_bytes()).await?;
+
+        match value {
+            Value::Boolean(exists) => Ok(exists),
+            _ => Err(Error::BadResponse),
+        }
+    }
+
     async fn increment(&self, key: &[u8], _: Option<KeyType>) -> Result<i64> {
         let mut args = Vec::with_capacity(1);
         args.push(key.to_vec());

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -113,6 +113,37 @@ impl<B: Backend> Client<B> {
         Echo::new(self.backend(), content)
     }
 
+    /// Check if one or more keys exist.
+    ///
+    /// Returns `true` if all of the keys exist, or `false` if at least one of
+    /// them does not.
+    ///
+    /// Refer to the documentation for the [`Exists`] request for more
+    /// information on how to use the request struct returned by this method.
+    ///
+    /// This is an `O(n)` time complexity operation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hop::Client;
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::memory();
+    /// // "foo" doesn't exist
+    /// assert!(!client.exists().key("foo").await?);
+    /// client.increment("foo").await?;
+    ///
+    /// // and now it does
+    /// assert!(client.exists().key("foo").await?);
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// [`Exists`]: request/exists/struct.Exists.html
+    pub fn exists(&self) -> Exists<B> {
+        Exists::new(self.backend())
+    }
+
     /// Increments a float or integer key by one.
     ///
     /// Returns the new value on success.

--- a/client/src/request/exists.rs
+++ b/client/src/request/exists.rs
@@ -1,0 +1,153 @@
+use super::MaybeInFlightFuture;
+use crate::Backend;
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+#[derive(Clone, Debug)]
+pub enum ExistsError {
+    NoKeys,
+    TooManyKeys,
+}
+
+impl Display for ExistsError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::NoKeys => f.write_str("no keys were provided"),
+            Self::TooManyKeys => f.write_str("too many keys were provided"),
+        }
+    }
+}
+
+impl Error for ExistsError {}
+
+/// Request to determine whether one or more keys exist.
+///
+/// Without creating a trait, it's not possible using the standard library to
+/// cleanly represent "this argument can either be one argument or an iterator
+/// of argument." Because of this, [`Client::exists`] returns this intermediary
+/// struct which contains two methods, [`key`] and [`keys`].
+///
+/// After using one of these methods, you'll get back a separate "finalised"
+/// request struct, which is ready to be `await`ed with your key arguments.
+///
+/// # Examples
+///
+/// Check if one, and then two, keys exist:
+///
+/// ```
+/// use hop::Client;
+///
+/// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let client = Client::memory();
+/// // make a "foo" key
+/// client.increment("foo").await?;
+/// // and now check that it exists
+/// assert!(client.exists().key("foo").await?);
+///
+/// // now check if "foo" *and* "bar" exist - clearly "bar" doesn't exist, so
+/// // this will be false.
+/// //
+/// // additionally, `keys` can error if you provide 0 or more than 255
+/// // arguments
+/// assert!(!client.exists().keys(&["foo", "bar"])?.await?);
+/// # Ok(()) }
+/// ```
+///
+/// [`Client::exists`]: ../../struct.Client.html#method.exists
+/// [`key`]: #method.key
+/// [`keys`]: #method.keys
+pub struct Exists<B: Backend> {
+    backend: Arc<B>,
+}
+
+impl<'a, B: Backend> Exists<B> {
+    pub(crate) fn new(backend: Arc<B>) -> Self {
+        Self { backend }
+    }
+
+    /// Check that a single key exists.
+    ///
+    /// Refer to the [struct docs] for more information.
+    ///
+    /// [struct docs]: #main
+    pub fn key<K: AsRef<[u8]> + 'a + Unpin + Send + Sync>(
+        self,
+        key: K,
+    ) -> ExistsConfigured<'a, B, K> {
+        let mut keys = Vec::new();
+        keys.push(key);
+
+        ExistsConfigured::new(self.backend, keys)
+    }
+
+    /// Check that one or more keys exist.
+    ///
+    /// Refer to the [struct docs] for more information.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExistsError::NoKeys`] if no keys were provided.
+    ///
+    /// Returns [`ExistsError::TooManyKeys`] if more than the argument limit
+    /// (255) worth of keys were provided.
+    ///
+    /// [`ExistsError::NoKeys`]: enum.ExistsError.html#variant.NoKeys
+    /// [`ExistsError::TooManyKeys`]: enum.ExistsError.html#variant.TooManyKeys
+    /// [struct docs]: #main
+    pub fn keys<K: AsRef<[u8]> + 'a + Unpin + Send + Sync>(
+        self,
+        keys: impl IntoIterator<Item = K>,
+    ) -> Result<ExistsConfigured<'a, B, K>, ExistsError> {
+        let keys: Vec<K> = keys.into_iter().collect();
+
+        if keys.is_empty() {
+            return Err(ExistsError::NoKeys);
+        } else if keys.len() > u8::MAX as usize {
+            return Err(ExistsError::TooManyKeys);
+        }
+
+        Ok(ExistsConfigured::new(self.backend, keys))
+    }
+}
+
+/// A configured request to check if one or more keys exist.
+pub struct ExistsConfigured<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin + Send + Sync> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, bool, B::Error>,
+    keys: Option<Vec<K>>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin + Send + Sync> ExistsConfigured<'a, B, K> {
+    fn new(backend: Arc<B>, keys: Vec<K>) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            keys: Some(keys),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + 'a + Unpin + Send + Sync> Future
+    for ExistsConfigured<'a, B, K>
+{
+    type Output = Result<bool, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = { self.backend.take().expect("backend only taken once") };
+            let keys = self.keys.take().expect("keys only taken once");
+
+            self.fut.replace(Box::pin(
+                async move { backend.exists((*keys).iter()).await },
+            ));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}

--- a/client/src/request/mod.rs
+++ b/client/src/request/mod.rs
@@ -1,3 +1,5 @@
+pub mod exists;
+
 mod decrement;
 mod delete;
 mod echo;
@@ -6,7 +8,12 @@ mod rename;
 mod stats;
 
 pub use self::{
-    decrement::Decrement, delete::Delete, echo::Echo, increment::Increment, rename::Rename,
+    decrement::Decrement,
+    delete::Delete,
+    echo::Echo,
+    exists::{Exists, ExistsConfigured},
+    increment::Increment,
+    rename::Rename,
     stats::Stats,
 };
 

--- a/engine/src/command/command_id.rs
+++ b/engine/src/command/command_id.rs
@@ -22,6 +22,7 @@ pub enum CommandId {
     IncrementBy = 2,
     DecrementBy = 3,
     Delete = 12,
+    Exists = 13,
     Rename = 15,
     Append = 20,
     Length = 21,
@@ -38,6 +39,7 @@ impl CommandId {
             Append => One,
             Delete => One,
             Echo => Multiple,
+            Exists => Multiple,
             Increment => None,
             IncrementBy => One,
             Decrement => None,
@@ -68,6 +70,7 @@ impl CommandId {
             Self::Decrement => "decrement",
             Self::Delete => "delete",
             Self::Echo => "echo",
+            Self::Exists => "exists",
             Self::IncrementBy => "increment:by",
             Self::Increment => "increment",
             Self::Rename => "rename",
@@ -93,6 +96,7 @@ impl FromStr for CommandId {
             "decrement" => Self::Decrement,
             "delete" => Self::Delete,
             "echo" => Self::Echo,
+            "exists" => Self::Exists,
             "increment:by" => Self::IncrementBy,
             "increment" => Self::Increment,
             "rename" => Self::Rename,
@@ -113,6 +117,7 @@ impl TryFrom<u8> for CommandId {
             2 => Self::IncrementBy,
             3 => Self::DecrementBy,
             12 => Self::Delete,
+            13 => Self::Exists,
             15 => Self::Rename,
             20 => Self::Append,
             21 => Self::Length,
@@ -172,6 +177,7 @@ mod tests {
         );
         assert_eq!(CommandId::Delete, CommandId::from_str("delete").unwrap());
         assert_eq!(CommandId::Echo, CommandId::from_str("echo").unwrap());
+        assert_eq!(CommandId::Exists, CommandId::from_str("exists").unwrap());
         assert_eq!(
             CommandId::IncrementBy,
             CommandId::from_str("increment:by").unwrap()
@@ -192,6 +198,7 @@ mod tests {
         assert_eq!(CommandId::Decrement, CommandId::try_from(1).unwrap());
         assert_eq!(CommandId::Delete, CommandId::try_from(12).unwrap());
         assert_eq!(CommandId::Echo, CommandId::try_from(100).unwrap());
+        assert_eq!(CommandId::Exists, CommandId::try_from(13).unwrap());
         assert_eq!(CommandId::IncrementBy, CommandId::try_from(2).unwrap());
         assert_eq!(CommandId::Increment, CommandId::try_from(0).unwrap());
         assert_eq!(CommandId::Rename, CommandId::try_from(15).unwrap());
@@ -206,6 +213,7 @@ mod tests {
         assert_eq!("decrement", CommandId::Decrement.name());
         assert_eq!("delete", CommandId::Delete.name());
         assert_eq!("echo", CommandId::Echo.name());
+        assert_eq!("exists", CommandId::Exists.name());
         assert_eq!("increment:by", CommandId::IncrementBy.name());
         assert_eq!("increment", CommandId::Increment.name());
         assert_eq!("rename", CommandId::Rename.name());

--- a/engine/src/command/impl/exists.rs
+++ b/engine/src/command/impl/exists.rs
@@ -1,0 +1,123 @@
+use super::super::{response, Dispatch, DispatchError, DispatchResult, Request};
+use crate::Hop;
+use alloc::vec::Vec;
+
+pub struct Exists;
+
+impl Dispatch for Exists {
+    fn dispatch(hop: &Hop, req: &Request, resp: &mut Vec<u8>) -> DispatchResult<()> {
+        if req.key_type().is_some() {
+            return Err(DispatchError::KeyTypeUnexpected);
+        }
+
+        let args = req.args().ok_or(DispatchError::ArgumentRetrieval)?;
+        let state = hop.state();
+
+        let all = args.iter().all(|key| state.contains_key(key));
+
+        response::write_bool(resp, all);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Exists;
+    use crate::{
+        command::{CommandId, Dispatch, DispatchError, Request, Response},
+        state::{KeyType, Value},
+        Hop,
+    };
+    use alloc::vec::Vec;
+
+    fn args() -> Vec<Vec<u8>> {
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        args.push(b"bar".to_vec());
+
+        args
+    }
+
+    #[test]
+    fn test_one_key() {
+        let mut args = args();
+        args.pop();
+        let req = Request::new(CommandId::Exists, Some(args));
+        let mut resp = Vec::new();
+
+        let hop = Hop::new();
+        hop.state()
+            .insert(b"foo".to_vec(), Value::Bytes([1, 2, 3].to_vec()));
+
+        assert!(Exists::dispatch(&hop, &req, &mut resp).is_ok());
+        assert_eq!(resp, Response::from(true).as_bytes());
+    }
+
+    #[test]
+    fn test_two_keys_both_exist() {
+        let args = args();
+        let req = Request::new(CommandId::Exists, Some(args));
+        let mut resp = Vec::new();
+
+        let hop = Hop::new();
+        hop.state()
+            .insert(b"foo".to_vec(), Value::Bytes([1, 2, 3].to_vec()));
+        hop.state()
+            .insert(b"bar".to_vec(), Value::Bytes([1, 2, 3].to_vec()));
+
+        assert!(Exists::dispatch(&hop, &req, &mut resp).is_ok());
+        assert_eq!(resp, Response::from(true).as_bytes());
+    }
+
+    #[test]
+    fn test_two_keys_one_exists() {
+        let args = args();
+        let req = Request::new(CommandId::Exists, Some(args));
+        let mut resp = Vec::new();
+
+        let hop = Hop::new();
+        hop.state()
+            .insert(b"foo".to_vec(), Value::Bytes([1, 2, 3].to_vec()));
+
+        assert!(Exists::dispatch(&hop, &req, &mut resp).is_ok());
+        assert_eq!(resp, Response::from(false).as_bytes());
+    }
+
+    #[test]
+    fn test_one_key_doesnt_exist() {
+        let mut args = args();
+        args.pop();
+        let req = Request::new(CommandId::Exists, Some(args));
+        let mut resp = Vec::new();
+
+        let hop = Hop::new();
+
+        assert!(Exists::dispatch(&hop, &req, &mut resp).is_ok());
+        assert_eq!(resp, Response::from(false).as_bytes());
+    }
+
+    #[test]
+    fn test_no_arguments() {
+        let req = Request::new(CommandId::Exists, None);
+        let mut resp = Vec::new();
+
+        let hop = Hop::new();
+        assert!(matches!(
+            Exists::dispatch(&hop, &req, &mut resp),
+            Err(DispatchError::ArgumentRetrieval)
+        ));
+    }
+
+    #[test]
+    fn test_key_type_specified() {
+        let req = Request::new_with_type(CommandId::Exists, Some(args()), KeyType::List);
+        let mut resp = Vec::new();
+
+        let hop = Hop::new();
+        assert!(matches!(
+            Exists::dispatch(&hop, &req, &mut resp),
+            Err(DispatchError::KeyTypeUnexpected)
+        ));
+    }
+}

--- a/engine/src/command/impl/mod.rs
+++ b/engine/src/command/impl/mod.rs
@@ -3,6 +3,7 @@ mod decrement;
 mod decrement_by;
 mod delete;
 mod echo;
+mod exists;
 mod increment;
 mod increment_by;
 mod length;
@@ -11,5 +12,6 @@ mod stats;
 
 pub use self::{
     append::Append, decrement::Decrement, decrement_by::DecrementBy, delete::Delete, echo::Echo,
-    increment::Increment, increment_by::IncrementBy, length::Length, rename::Rename, stats::Stats,
+    exists::Exists, increment::Increment, increment_by::IncrementBy, length::Length,
+    rename::Rename, stats::Stats,
 };

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -46,6 +46,7 @@ impl Hop {
             CommandId::Decrement => Decrement::dispatch(self, req, res),
             CommandId::Delete => Delete::dispatch(self, req, res),
             CommandId::Echo => Echo::dispatch(self, req, res),
+            CommandId::Exists => Exists::dispatch(self, req, res),
             CommandId::Increment => Increment::dispatch(self, req, res),
             CommandId::IncrementBy => IncrementBy::dispatch(self, req, res),
             CommandId::Rename => Rename::dispatch(self, req, res),


### PR DESCRIPTION
Add an 'exists' command to the engine, supporting it in the client and
CLI.

The exists command checks if one or more keys exist. If all exist, then
`true` is returned. If at least one does not exist, then `false` is
returned.

If a key type is provided, then a `DispatchError::UnexpectedKeyType` is
returned.

If no arguments are provided, then a `DispatchError::ArgumentRetrieval`
is returned.

Using the CLI looks like this:

```
> exists
At least one key is required.
> exists foo
false
> set foo 123
123
> exists foo
true
```

Closes issue #19.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>