### PR TITLE
engine/response/context: don't reset on every iter

### DIFF
--- a/engine/benches/bench_protocol.rs
+++ b/engine/benches/bench_protocol.rs
@@ -3,15 +3,38 @@
 
 extern crate test;
 
-use hop_engine::command::request::Context;
+use core::iter;
+use hop_engine::command::{
+    request::Context as RequestContext,
+    response::{Context as ResponseContext, Instruction as ResponseInstruction, Response},
+};
 use test::Bencher;
 
 #[bench]
 fn bench_simple_increment(b: &mut Bencher) {
-    let mut ctx = Context::new();
+    let mut ctx = RequestContext::new();
     let input = test::black_box([0].to_vec());
 
     b.iter(|| {
         ctx.feed(&input).unwrap();
+    });
+}
+
+#[bench]
+fn bench_response_list(b: &mut Bencher) {
+    let mut list: Vec<Vec<u8>> = Vec::new();
+    for _ in 0..15 {
+        list.push(iter::repeat(b'a').take(10).collect::<Vec<u8>>());
+    }
+
+    let response = Response::from(list);
+    let bytes = response.as_bytes();
+    let mut ctx = ResponseContext::new();
+
+    b.iter(|| {
+        assert!(matches!(
+            ctx.feed(&bytes),
+            Ok(ResponseInstruction::Concluded(_))
+        ));
     });
 }

--- a/engine/src/command/response/context.rs
+++ b/engine/src/command/response/context.rs
@@ -111,11 +111,12 @@ impl Context {
             };
 
             match instruction {
-                Some(instruction) => {
+                Some(Instruction::Concluded(response)) => {
                     self.reset();
 
-                    return Ok(instruction);
+                    return Ok(Instruction::Concluded(response));
                 }
+                Some(Instruction::ReadBytes(amount)) => return Ok(Instruction::ReadBytes(amount)),
                 None => continue,
             }
         }
@@ -235,7 +236,7 @@ impl Context {
         let arg = match buf.get(arg_size_end..arg_value_end) {
             Some(arg) => arg,
             None => {
-                let remaining = remaining_bytes(arg_size_end, buf.len(), arg_value_end);
+                let remaining = arg_value_end - buf.len();
 
                 return Ok(Some(Instruction::ReadBytes(remaining)));
             }


### PR DESCRIPTION
The response context was inadvertently resetting the state on every
iteration, which was essentially throwing away a lot of a message's
processing on every iteration. Instead, only reset the state when a
message has completed parsing.

Take a scenario where a 15-element list of 100 byte elements is
transmitted over network. To parse this, a consumer will read the first
byte, which will be feed to the parser. The parser says it's a list and
to get 2 more bytes, so the consumer reads 2 more bytes, passes it to
the parser, and so on. For this list this will result in 62 reads to
completion. By not resetting the state, the time to parse this list
(minus networking) is reduced from:

```
test bench_response_list    ... bench:      13,033 ns/iter (+/- 1,666)
```

to:

```
test bench_response_list    ... bench:       3,681 ns/iter (+/- 184)
```

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>