### PR TITLE
engine: optimise response format

### DIFF
--- a/client/src/backend/memory.rs
+++ b/client/src/backend/memory.rs
@@ -143,10 +143,19 @@ impl Backend for MemoryBackend {
 
         self.hop.dispatch(&req, &mut resp)?;
 
-        let arr = resp.get(1..9).unwrap().try_into().unwrap();
-        let num = i64::from_be_bytes(arr);
+        let mut ctx = Context::new();
 
-        Ok(num)
+        let resp = match ctx.feed(&resp).unwrap() {
+            Instruction::Concluded(value) => value,
+            Instruction::ReadBytes(_) => unreachable!(),
+        };
+
+        let int = match resp {
+            Response::Value(Value::Integer(int)) => int,
+            _ => panic!(),
+        };
+
+        Ok(int)
     }
 
     async fn rename(&self, from: &[u8], to: &[u8]) -> Result<Vec<u8>, Self::Error> {


### PR DESCRIPTION
Optimise the response format by prepending 4 bytes representing a u32 as
the header of every response message. This can be used by clients to
immediately know how many bytes to read from a stream, instead of
dynamically re-reading from a stream when a length of a key is
determined, or the length of a value is determined, etc.

Taking an example of dynamically reading and parsing a 15-element list
of 100 byte elements over a TCP stream, this would previously require a
minimum of 31 `read(2)` syscalls: 1 to read the key type, another to
read the first item's length in bytes, another to read the first item's
value, another to read the second item's length in bytes, and so on.

Using this new format, a minimum of 2 `read(2)` syscalls are required: 1
to read the message length (containing the length of the key type and
information about the list), and a second to actually read the message
in its entirety.

With this patch, reading a message using this scheme reduces the parsing
time from (minus networking):

```
test bench_response_list    ... bench:       3,681 ns/iter (+/- 184)
```

to:

```
test bench_response_list    ... bench:         493 ns/iter (+/- 44)
```

For comparison, using `serde_cbor`[1] to simply deserialise this same
list would take this long:

```
test bench_response_list    ... bench:       1,671 ns/iter (+/- 158)
```

[1]: https://docs.rs/serde_cbor/0.11.1/serde_cbor/

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>