### PR TITLE
client: fix trimming of echo output

### DIFF
--- a/cli/src/input.rs
+++ b/cli/src/input.rs
@@ -83,7 +83,7 @@ mod tests {
         let req = super::process_command(&mut reader, &mut buf).await?;
 
         assert_eq!(req.kind(), CommandId::Echo);
-        assert_eq!(req.arg(0), Some(&b"abc".to_vec()));
+        assert_eq!(req.arg(0), Some("abc".as_bytes()));
 
         Ok(())
     }
@@ -96,7 +96,7 @@ mod tests {
         let req = super::process_command(&mut reader, &mut buf).await?;
 
         assert_eq!(req.kind(), CommandId::Echo);
-        assert!(req.args().is_none());
+        assert!(req.args(..).is_none());
 
         Ok(())
     }

--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -15,7 +15,7 @@ pub trait Backend {
 
     async fn delete(&self, key: &[u8]) -> Result<Vec<u8>, Self::Error>;
 
-    async fn echo(&self, content: &[u8]) -> Result<Vec<u8>, Self::Error>;
+    async fn echo(&self, content: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error>;
 
     async fn exists<T: IntoIterator<Item = U> + Send, U: AsRef<[u8]> + Send>(
         &self,

--- a/client/src/backend/server.rs
+++ b/client/src/backend/server.rs
@@ -159,7 +159,7 @@ impl Backend for ServerBackend {
         }
     }
 
-    async fn echo(&self, content: &[u8]) -> Result<Vec<u8>> {
+    async fn echo(&self, content: &[u8]) -> Result<Vec<Vec<u8>>> {
         let mut args = Vec::with_capacity(1);
         args.push(content.to_vec());
         let req = Request::new(CommandId::Echo, Some(args));
@@ -167,7 +167,7 @@ impl Backend for ServerBackend {
         let value = self.send_and_wait(&req.into_bytes()).await?;
 
         match value {
-            Value::Bytes(bytes) => Ok(bytes),
+            Value::List(args) => Ok(args),
             _ => Err(Error::BadResponse),
         }
     }

--- a/client/src/request/echo.rs
+++ b/client/src/request/echo.rs
@@ -10,7 +10,7 @@ use std::{
 pub struct Echo<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
     backend: Option<Arc<B>>,
     content: Option<K>,
-    fut: MaybeInFlightFuture<'a, Vec<u8>, B::Error>,
+    fut: MaybeInFlightFuture<'a, Vec<Vec<u8>>, B::Error>,
 }
 
 impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> Echo<'a, B, K> {
@@ -24,7 +24,7 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> Echo<'a, B, K> {
 }
 
 impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for Echo<'a, B, K> {
-    type Output = Result<Vec<u8>, B::Error>;
+    type Output = Result<Vec<Vec<u8>>, B::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if self.fut.is_none() {

--- a/engine/src/command/impl/append.rs
+++ b/engine/src/command/impl/append.rs
@@ -15,7 +15,7 @@ pub struct Append;
 impl Dispatch for Append {
     fn dispatch(hop: &Hop, req: &Request, resp: &mut Vec<u8>) -> DispatchResult<()> {
         let key = req.arg(0).ok_or(DispatchError::KeyRetrieval)?;
-        let args = req.arg(1..).ok_or(DispatchError::ArgumentRetrieval)?;
+        let args = req.args(1..).ok_or(DispatchError::ArgumentRetrieval)?;
 
         match req.key_type() {
             Some(KeyType::Bytes) | None => {

--- a/engine/src/command/impl/echo.rs
+++ b/engine/src/command/impl/echo.rs
@@ -6,7 +6,7 @@ pub struct Echo;
 
 impl Dispatch for Echo {
     fn dispatch(_: &Hop, req: &Request, resp: &mut Vec<u8>) -> DispatchResult<()> {
-        match req.args() {
+        match req.args(..) {
             Some(args) => response::write_list(resp, args),
             None => response::write_list(resp, &[]),
         }

--- a/engine/src/command/impl/exists.rs
+++ b/engine/src/command/impl/exists.rs
@@ -10,7 +10,7 @@ impl Dispatch for Exists {
             return Err(DispatchError::KeyTypeUnexpected);
         }
 
-        let args = req.args().ok_or(DispatchError::ArgumentRetrieval)?;
+        let args = req.args(..).ok_or(DispatchError::ArgumentRetrieval)?;
         let state = hop.state();
 
         let all = args.iter().all(|key| state.contains_key(key));


### PR DESCRIPTION
Fix the client's echo command from trimming off the last byte of the
response by properly parsing the response.

Closes issue #3.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>