### PR TITLE
engine: add 'set' command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,7 @@ name = "hop"
 version = "0.1.0"
 dependencies = [
  "async-trait 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dashmap 3.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hop-engine 0.1.0",
  "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -13,6 +13,7 @@ version = "0.1.0"
 
 [dependencies]
 async-trait = { default-features = false, version = "^0.1.30" }
+dashmap = { default-features = false, version = "^3.11.1" }
 hop-engine = { default-features = false, path = "../engine" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -10,7 +10,7 @@ pub use self::server::ServerBackend;
 
 use crate::model::StatsData;
 use async_trait::async_trait;
-use hop_engine::state::KeyType;
+use hop_engine::state::{KeyType, Value};
 
 #[async_trait]
 pub trait Backend {
@@ -30,6 +30,8 @@ pub trait Backend {
     async fn increment(&self, key: &[u8], key_type: Option<KeyType>) -> Result<i64, Self::Error>;
 
     async fn rename(&self, from: &[u8], to: &[u8]) -> Result<Vec<u8>, Self::Error>;
+
+    async fn set<T: Into<Value> + Send>(&self, key: &[u8], value: T) -> Result<Value, Self::Error>;
 
     async fn stats(&self) -> Result<StatsData, Self::Error>;
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -192,6 +192,34 @@ impl<B: Backend> Client<B> {
         Rename::new(self.backend(), from, to)
     }
 
+    /// Set a key to a new value, overriding it regardless of whether it exists
+    /// and its current key type.
+    ///
+    /// Returns the new value on success as confirmation.
+    ///
+    /// Refer to [`SetUnconfigured`] for more information and available methods.
+    ///
+    /// # Examples
+    ///
+    /// Set the key "foo" to the integer `123`, and then set "foo" to the string
+    /// "bar".
+    ///
+    /// ```
+    /// use hop::Client;
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::memory();
+    /// assert_eq!(123, client.set("foo").int(123).await?);
+    ///
+    /// assert_eq!("bar", client.set("foo").string("bar").await?);
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// [`SetUnconfigured`]: request/set/struct.SetUnconfigured.html
+    pub fn set<K: AsRef<[u8]> + Unpin>(&self, key: K) -> SetUnconfigured<B, K> {
+        SetUnconfigured::new(self.backend(), key)
+    }
+
     /// Retrieve statistics about the current runtime of Hop.
     ///
     /// When Hop is restarted, many of the statistics - like commands run - are

--- a/client/src/request/mod.rs
+++ b/client/src/request/mod.rs
@@ -1,4 +1,5 @@
 pub mod exists;
+pub mod set;
 
 mod decrement;
 mod delete;
@@ -14,6 +15,7 @@ pub use self::{
     exists::{Exists, ExistsConfigured},
     increment::Increment,
     rename::Rename,
+    set::{SetBytes, SetUnconfigured},
     stats::Stats,
 };
 

--- a/client/src/request/set/mod.rs
+++ b/client/src/request/set/mod.rs
@@ -1,0 +1,280 @@
+mod set_boolean;
+mod set_bytes;
+mod set_float;
+mod set_integer;
+mod set_list;
+mod set_map;
+mod set_set;
+mod set_string;
+mod set_value;
+
+pub use self::{
+    set_boolean::SetBoolean, set_bytes::SetBytes, set_float::SetFloat, set_integer::SetInteger,
+    set_list::SetList, set_map::SetMap, set_set::SetSet, set_string::SetString,
+    set_value::SetValue,
+};
+
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{iter::FromIterator, sync::Arc};
+
+/// An Set request that hasn't been configured with a value to set.
+///
+/// This is an intermediary that allows you to cleanly set a value knowing its
+/// type from just the method signature, and get back a value in the same type.
+///
+/// For example, if you call [`SetUnconfigured::bool`], then you will get back a
+/// configured [`SetBoolean`] struct which you can `await`. This struct will
+/// resolve to a boolean on success. If you call [`SetUnconfigured::int`], then
+/// you will get back a [`SetInteger`] which will resolve to an integer when
+/// `await`ed.
+///
+/// # Examples
+///
+/// Set the key "foo" to a boolean:
+///
+/// ```
+/// use hop::Client;
+///
+/// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let client = Client::memory();
+///
+/// // we know that it will resolve to a boolean on success
+/// let new_value: bool = client.set("foo").bool(true).await?;
+///
+/// if new_value {
+///     println!("Something when the new value is true");
+/// } else {
+///     println!("Or when it's false");
+/// }
+/// # Ok(()) }
+/// ```
+///
+/// [`SetUnconfigured::bool`]: #method.bool
+/// [`SetUnconfigured::int`]: #method.int
+/// [`SetBoolean`]: struct.SetBoolean.html
+/// [`SetInteger`]: struct.SetInteger.html
+pub struct SetUnconfigured<B: Backend, K: AsRef<[u8]> + Unpin> {
+    backend: Arc<B>,
+    key: K,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetUnconfigured<B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
+        Self { backend, key }
+    }
+
+    /// An alias for [`bool`].
+    ///
+    /// [`bool`]: #method.bool
+    pub fn boolean(self, boolean: bool) -> SetBoolean<'a, B, K> {
+        self.bool(boolean)
+    }
+
+    /// Set a key to a boolean.
+    ///
+    /// The returned struct, when `await`ed, will resolve to a boolean on
+    /// success.
+    ///
+    /// # Examples
+    ///
+    /// Set the key "foo" to `true`:
+    ///
+    /// ```
+    /// use hop::Client;
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::memory();
+    /// client.set("foo").bool(true).await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn bool(self, boolean: bool) -> SetBoolean<'a, B, K> {
+        SetBoolean::new(self.backend, self.key, boolean)
+    }
+
+    /// Set a key to some bytes.
+    ///
+    /// The returned struct, when `await`ed, will resolve to a `Vec<u8>` on
+    /// success.
+    ///
+    /// # Examples
+    ///
+    /// Set the key "foo" to the bytes `[1, 2, 3, 4, 5]`:
+    ///
+    /// ```
+    /// use hop::Client;
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::memory();
+    /// client.set("foo").bytes([1u8, 2, 3, 4, 5].as_ref()).await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn bytes(self, bytes: impl Into<Vec<u8>>) -> SetBytes<'a, B, K> {
+        SetBytes::new(self.backend, self.key, bytes.into())
+    }
+
+    /// Set a key to a float.
+    ///
+    /// The returned struct, when `await`ed, will resolve to a float on success.
+    ///
+    /// # Examples
+    ///
+    /// Set the key "foo" to `1.23`:
+    ///
+    /// ```
+    /// use hop::Client;
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::memory();
+    /// client.set("foo").float(1.23).await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn float(self, float: f64) -> SetFloat<'a, B, K> {
+        SetFloat::new(self.backend, self.key, float)
+    }
+
+    /// An alias for [`int`].
+    ///
+    /// [`int`]: #method.int
+    pub fn integer(self, integer: i64) -> SetInteger<'a, B, K> {
+        self.int(integer)
+    }
+
+    /// Set a key to an integer.
+    ///
+    /// The returned struct, when `await`ed, will resolve to an integer on
+    /// success.
+    ///
+    /// # Examples
+    ///
+    /// Set the key "foo" to `123`:
+    ///
+    /// ```
+    /// use hop::Client;
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::memory();
+    /// client.set("foo").int(123).await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn int(self, integer: i64) -> SetInteger<'a, B, K> {
+        SetInteger::new(self.backend, self.key, integer)
+    }
+
+    /// Set a key to an list.
+    ///
+    /// The returned struct, when `await`ed, will resolve to a list on success.
+    ///
+    /// # Examples
+    ///
+    /// Set the key "foo" to the list:
+    ///
+    /// - "foo"
+    /// - "bar"
+    /// - "baz"
+    ///
+    /// ```
+    /// use hop::Client;
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::memory();
+    /// client.set("foo").list([b"foo".to_vec(), b"bar".to_vec(), b"baz".to_vec()].as_ref()).await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn list(self, list: impl Into<Vec<Vec<u8>>>) -> SetList<'a, B, K> {
+        SetList::new(self.backend, self.key, list.into())
+    }
+
+    pub fn map<T: IntoIterator<Item = (U, U)>, U: Into<Vec<u8>>>(self, map: T) -> SetMap<'a, B, K> {
+        SetMap::new(
+            self.backend,
+            self.key,
+            FromIterator::from_iter(map.into_iter().map(|(k, v)| (k.into(), v.into()))),
+        )
+    }
+
+    /// Set a key to an list.
+    ///
+    /// The returned struct, when `await`ed, will resolve to a list on success.
+    ///
+    /// # Examples
+    ///
+    /// Set the key "foo" to the set:
+    ///
+    /// - "foo"
+    /// - "bar"
+    /// - "foo"
+    ///
+    /// Then, confirm that it has only 2 items, since there are duplicate
+    /// "foo"s.
+    ///
+    /// ```
+    /// use hop::Client;
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::memory();
+    /// let set = client.set("foo").set([b"foo".to_vec(), b"bar".to_vec(), b"foo".to_vec()].to_vec()).await?;
+    ///
+    /// assert_eq!(2, set.len());
+    /// # Ok(()) }
+    /// ```
+    pub fn set(self, set: impl Into<Vec<Vec<u8>>>) -> SetSet<'a, B, K> {
+        SetSet::new(self.backend, self.key, FromIterator::from_iter(set.into()))
+    }
+
+    /// An alias for [`str`].
+    ///
+    /// [`str`]: #method.str
+    #[inline]
+    pub fn string(self, string: impl Into<String>) -> SetString<'a, B, K> {
+        self.str(string)
+    }
+
+    /// Set a key to a string.
+    ///
+    /// The returned struct, when `await`ed, will resolve to a string on
+    /// success.
+    ///
+    /// # Examples
+    ///
+    /// Set the key "foo" to the string "bar":
+    ///
+    /// ```
+    /// use hop::Client;
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::memory();
+    /// client.set("foo").str("bar").await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn str(self, string: impl Into<String>) -> SetString<'a, B, K> {
+        SetString::new(self.backend, self.key, string.into())
+    }
+
+    /// Set a value to that of a raw engine state value.
+    ///
+    /// This is mainly useful when you are heavily working with the engine
+    /// directly.
+    ///
+    /// The returned struct, when `await`ed, will resolve to a value that will
+    /// be equivalent to the one provided.
+    ///
+    /// # Examples
+    ///
+    /// Set the key "foo" to a value containing the string "bar":
+    ///
+    /// ```
+    /// use hop::Client;
+    /// use hop_engine::state::Value;
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::memory();
+    /// let value = Value::String("bar".to_owned());
+    ///
+    /// client.set("foo").value(value).await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn value(self, value: impl Into<Value>) -> SetValue<'a, B, K> {
+        SetValue::new(self.backend, self.key, value.into())
+    }
+}

--- a/client/src/request/set/set_boolean.rs
+++ b/client/src/request/set/set_boolean.rs
@@ -1,0 +1,57 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `set` command that will resolve to a boolean when `await`ed.
+///
+/// This is returned by [`SetUnconfigured::bool`].
+///
+/// [`SetUnconfigured::bool`]: struct.SetUnconfigured.html#method.bool
+pub struct SetBoolean<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, bool, B::Error>,
+    key: Option<K>,
+    value: Option<bool>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetBoolean<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K, value: bool) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+            value: Some(value),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future
+    for SetBoolean<'a, B, K>
+{
+    type Output = Result<bool, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+            let bool = self.value.take().expect("value only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let value = backend.set(key.as_ref(), Value::Boolean(bool)).await?;
+
+                match value {
+                    Value::Boolean(bool) => Ok(bool),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}

--- a/client/src/request/set/set_bytes.rs
+++ b/client/src/request/set/set_bytes.rs
@@ -1,0 +1,55 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `set` command that will resolve to bytes when `await`ed.
+///
+/// This is returned by [`SetUnconfigured::bytes`].
+///
+/// [`SetUnconfigured::bytes`]: struct.SetUnconfigured.html#method.bytes
+pub struct SetBytes<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, Vec<u8>, B::Error>,
+    key: Option<K>,
+    value: Option<Vec<u8>>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetBytes<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K, value: Vec<u8>) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+            value: Some(value),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for SetBytes<'a, B, K> {
+    type Output = Result<Vec<u8>, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+            let value = self.value.take().expect("value only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let value = backend.set(key.as_ref(), Value::Bytes(value)).await?;
+
+                match value {
+                    Value::Bytes(bytes) => Ok(bytes),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}

--- a/client/src/request/set/set_float.rs
+++ b/client/src/request/set/set_float.rs
@@ -1,0 +1,55 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `set` command that will resolve to a float when `await`ed.
+///
+/// This is returned by [`SetUnconfigured::float`].
+///
+/// [`SetUnconfigured::float`]: struct.SetUnconfigured.html#method.float
+pub struct SetFloat<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, f64, B::Error>,
+    key: Option<K>,
+    value: Option<f64>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetFloat<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K, value: f64) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+            value: Some(value),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for SetFloat<'a, B, K> {
+    type Output = Result<f64, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+            let float = self.value.take().expect("value only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let value = backend.set(key.as_ref(), Value::Float(float)).await?;
+
+                match value {
+                    Value::Float(float) => Ok(float),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}

--- a/client/src/request/set/set_integer.rs
+++ b/client/src/request/set/set_integer.rs
@@ -1,0 +1,57 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `set` command that will resolve to an integer when `await`ed.
+///
+/// This is returned by [`SetUnconfigured::int`].
+///
+/// [`SetUnconfigured::int`]: struct.SetUnconfigured.html#method.int
+pub struct SetInteger<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, i64, B::Error>,
+    key: Option<K>,
+    value: Option<i64>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetInteger<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K, value: i64) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+            value: Some(value),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future
+    for SetInteger<'a, B, K>
+{
+    type Output = Result<i64, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+            let int = self.value.take().expect("value only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let value = backend.set(key.as_ref(), Value::Integer(int)).await?;
+
+                match value {
+                    Value::Integer(int) => Ok(int),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}

--- a/client/src/request/set/set_list.rs
+++ b/client/src/request/set/set_list.rs
@@ -1,0 +1,55 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `set` command that will resolve to a list when `await`ed.
+///
+/// This is returned by [`SetUnconfigured::list`].
+///
+/// [`SetUnconfigured::list`]: struct.SetUnconfigured.html#method.list
+pub struct SetList<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, Vec<Vec<u8>>, B::Error>,
+    key: Option<K>,
+    value: Option<Vec<Vec<u8>>>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetList<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K, value: Vec<Vec<u8>>) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+            value: Some(value),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for SetList<'a, B, K> {
+    type Output = Result<Vec<Vec<u8>>, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+            let value = self.value.take().expect("value only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let value = backend.set(key.as_ref(), Value::List(value)).await?;
+
+                match value {
+                    Value::List(list) => Ok(list),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}

--- a/client/src/request/set/set_map.rs
+++ b/client/src/request/set/set_map.rs
@@ -1,0 +1,56 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use dashmap::DashMap;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `set` command that will resolve to a map when `await`ed.
+///
+/// This is returned by [`SetUnconfigured::map`].
+///
+/// [`SetUnconfigured::map`]: struct.SetUnconfigured.html#method.map
+pub struct SetMap<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, DashMap<Vec<u8>, Vec<u8>>, B::Error>,
+    key: Option<K>,
+    value: Option<DashMap<Vec<u8>, Vec<u8>>>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetMap<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K, value: DashMap<Vec<u8>, Vec<u8>>) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+            value: Some(value),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for SetMap<'a, B, K> {
+    type Output = Result<DashMap<Vec<u8>, Vec<u8>>, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+            let value = self.value.take().expect("value only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let value = backend.set(key.as_ref(), Value::Map(value)).await?;
+
+                match value {
+                    Value::Map(map) => Ok(map),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}

--- a/client/src/request/set/set_set.rs
+++ b/client/src/request/set/set_set.rs
@@ -1,0 +1,58 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    iter::FromIterator,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `set` command that will resolve to a set when `await`ed.
+///
+/// This is returned by [`SetUnconfigured::set`].
+///
+/// [`SetUnconfigured::set`]: struct.SetUnconfigured.html#method.set
+pub struct SetSet<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, Vec<Vec<u8>>, B::Error>,
+    key: Option<K>,
+    value: Option<Vec<Vec<u8>>>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetSet<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K, value: Vec<Vec<u8>>) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+            value: Some(value),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for SetSet<'a, B, K> {
+    type Output = Result<Vec<Vec<u8>>, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+            let value = self.value.take().expect("value only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let value = backend
+                    .set(key.as_ref(), Value::Set(FromIterator::from_iter(value)))
+                    .await?;
+
+                match value {
+                    Value::Set(set) => Ok(set.into_iter().collect()),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}

--- a/client/src/request/set/set_string.rs
+++ b/client/src/request/set/set_string.rs
@@ -1,0 +1,57 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `set` command that will resolve to a string when `await`ed.
+///
+/// This is returned by [`SetUnconfigured::string`].
+///
+/// [`SetUnconfigured::string`]: struct.SetUnconfigured.html#method.string
+pub struct SetString<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, String, B::Error>,
+    key: Option<K>,
+    value: Option<String>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetString<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K, value: String) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+            value: Some(value),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future
+    for SetString<'a, B, K>
+{
+    type Output = Result<String, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+            let value = self.value.take().expect("value only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let value = backend.set(key.as_ref(), Value::String(value)).await?;
+
+                match value {
+                    Value::String(string) => Ok(string),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}

--- a/client/src/request/set/set_value.rs
+++ b/client/src/request/set/set_value.rs
@@ -1,0 +1,51 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `set` command that will resolve to a generic engine value when
+/// `await`ed.
+///
+/// This is returned by [`SetUnconfigured::value`].
+///
+/// [`SetUnconfigured::value`]: struct.SetUnconfigured.html#method.value
+pub struct SetValue<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, Value, B::Error>,
+    key: Option<K>,
+    value: Option<Value>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetValue<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K, value: Value) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+            value: Some(value),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for SetValue<'a, B, K> {
+    type Output = Result<Value, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+            let value = self.value.take().expect("value only taken once");
+
+            self.fut.replace(Box::pin(
+                async move { backend.set(key.as_ref(), value).await },
+            ));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}

--- a/engine/src/command/command_id.rs
+++ b/engine/src/command/command_id.rs
@@ -21,6 +21,7 @@ pub enum CommandId {
     Decrement = 1,
     IncrementBy = 2,
     DecrementBy = 3,
+    Set = 10,
     Delete = 12,
     Exists = 13,
     Rename = 15,
@@ -44,9 +45,10 @@ impl CommandId {
             IncrementBy => One,
             Decrement => None,
             DecrementBy => One,
-            Rename => One,
-            Stats => None,
             Length => One,
+            Rename => One,
+            Set => Multiple,
+            Stats => None,
         }
     }
 
@@ -73,9 +75,10 @@ impl CommandId {
             Self::Exists => "exists",
             Self::IncrementBy => "increment:by",
             Self::Increment => "increment",
-            Self::Rename => "rename",
-            Self::Stats => "stats",
             Self::Length => "length",
+            Self::Rename => "rename",
+            Self::Set => "set",
+            Self::Stats => "stats",
         }
     }
 }
@@ -99,9 +102,10 @@ impl FromStr for CommandId {
             "exists" => Self::Exists,
             "increment:by" => Self::IncrementBy,
             "increment" => Self::Increment,
-            "rename" => Self::Rename,
-            "stats" => Self::Stats,
             "length" => Self::Length,
+            "rename" => Self::Rename,
+            "set" => Self::Set,
+            "stats" => Self::Stats,
             _ => return Err(InvalidCommandId),
         })
     }
@@ -116,6 +120,7 @@ impl TryFrom<u8> for CommandId {
             1 => Self::Decrement,
             2 => Self::IncrementBy,
             3 => Self::DecrementBy,
+            10 => Self::Set,
             12 => Self::Delete,
             13 => Self::Exists,
             15 => Self::Rename,
@@ -186,9 +191,10 @@ mod tests {
             CommandId::Increment,
             CommandId::from_str("increment").unwrap()
         );
-        assert_eq!(CommandId::Rename, CommandId::from_str("rename").unwrap());
-        assert_eq!(CommandId::Stats, CommandId::from_str("stats").unwrap());
         assert_eq!(CommandId::Length, CommandId::from_str("length").unwrap());
+        assert_eq!(CommandId::Rename, CommandId::from_str("rename").unwrap());
+        assert_eq!(CommandId::Set, CommandId::from_str("set").unwrap());
+        assert_eq!(CommandId::Stats, CommandId::from_str("stats").unwrap());
     }
 
     #[test]
@@ -201,9 +207,10 @@ mod tests {
         assert_eq!(CommandId::Exists, CommandId::try_from(13).unwrap());
         assert_eq!(CommandId::IncrementBy, CommandId::try_from(2).unwrap());
         assert_eq!(CommandId::Increment, CommandId::try_from(0).unwrap());
-        assert_eq!(CommandId::Rename, CommandId::try_from(15).unwrap());
-        assert_eq!(CommandId::Stats, CommandId::try_from(101).unwrap());
         assert_eq!(CommandId::Length, CommandId::try_from(21).unwrap());
+        assert_eq!(CommandId::Rename, CommandId::try_from(15).unwrap());
+        assert_eq!(CommandId::Set, CommandId::try_from(10).unwrap());
+        assert_eq!(CommandId::Stats, CommandId::try_from(101).unwrap());
     }
 
     #[test]
@@ -216,8 +223,9 @@ mod tests {
         assert_eq!("exists", CommandId::Exists.name());
         assert_eq!("increment:by", CommandId::IncrementBy.name());
         assert_eq!("increment", CommandId::Increment.name());
-        assert_eq!("rename", CommandId::Rename.name());
-        assert_eq!("stats", CommandId::Stats.name());
         assert_eq!("length", CommandId::Length.name());
+        assert_eq!("rename", CommandId::Rename.name());
+        assert_eq!("set", CommandId::Set.name());
+        assert_eq!("stats", CommandId::Stats.name());
     }
 }

--- a/engine/src/command/impl/mod.rs
+++ b/engine/src/command/impl/mod.rs
@@ -8,10 +8,11 @@ mod increment;
 mod increment_by;
 mod length;
 mod rename;
+mod set;
 mod stats;
 
 pub use self::{
     append::Append, decrement::Decrement, decrement_by::DecrementBy, delete::Delete, echo::Echo,
     exists::Exists, increment::Increment, increment_by::IncrementBy, length::Length,
-    rename::Rename, stats::Stats,
+    rename::Rename, set::Set, stats::Stats,
 };

--- a/engine/src/command/impl/set.rs
+++ b/engine/src/command/impl/set.rs
@@ -1,0 +1,340 @@
+use crate::{
+    command::{response, Dispatch, DispatchError, DispatchResult, Request},
+    state::{
+        object::{Boolean, Bytes, Float, Integer, List, Map, Set as SetObject, Str},
+        KeyType, Value,
+    },
+    Hop,
+};
+use alloc::{borrow::ToOwned, vec::Vec};
+
+pub struct Set;
+
+impl Set {
+    fn boolean(hop: &Hop, req: &Request, resp: &mut Vec<u8>, key: &[u8]) -> DispatchResult<()> {
+        let arg = req.typed_arg(1).ok_or(DispatchError::ArgumentRetrieval)?;
+        hop.state().remove(key);
+        let mut boolean = hop
+            .state()
+            .typed_key::<Boolean>(key)
+            .ok_or(DispatchError::WrongType)?;
+
+        *boolean = arg;
+
+        response::write_bool(resp, arg);
+
+        Ok(())
+    }
+
+    fn bytes(hop: &Hop, req: &Request, resp: &mut Vec<u8>, key: &[u8]) -> DispatchResult<()> {
+        let arg = req
+            .typed_arg::<&[u8]>(1)
+            .ok_or(DispatchError::ArgumentRetrieval)?;
+        hop.state().remove(key);
+        let mut bytes = hop
+            .state()
+            .typed_key::<Bytes>(key)
+            .ok_or(DispatchError::WrongType)?;
+
+        *bytes = arg.to_vec();
+
+        response::write_bytes(resp, arg);
+
+        Ok(())
+    }
+
+    fn float(hop: &Hop, req: &Request, resp: &mut Vec<u8>, key: &[u8]) -> DispatchResult<()> {
+        let arg = req.typed_arg(1).ok_or(DispatchError::ArgumentRetrieval)?;
+        hop.state().remove(key);
+        let mut float = hop
+            .state()
+            .typed_key::<Float>(key)
+            .ok_or(DispatchError::WrongType)?;
+
+        *float = arg;
+
+        response::write_float(resp, arg);
+
+        Ok(())
+    }
+
+    fn integer(hop: &Hop, req: &Request, resp: &mut Vec<u8>, key: &[u8]) -> DispatchResult<()> {
+        let arg = req.typed_arg(1).ok_or(DispatchError::ArgumentRetrieval)?;
+        hop.state().remove(key);
+        let mut int = hop
+            .state()
+            .typed_key::<Integer>(key)
+            .ok_or(DispatchError::WrongType)?;
+
+        *int = arg;
+
+        response::write_int(resp, arg);
+
+        Ok(())
+    }
+
+    fn list(hop: &Hop, req: &Request, resp: &mut Vec<u8>, key: &[u8]) -> DispatchResult<()> {
+        let args = req.args(1..).ok_or(DispatchError::ArgumentRetrieval)?;
+        hop.state().remove(key);
+        let mut list = hop
+            .state()
+            .typed_key::<List>(key)
+            .ok_or(DispatchError::WrongType)?;
+
+        *list = args.to_vec();
+
+        response::write_list(resp, args);
+
+        Ok(())
+    }
+
+    fn map(hop: &Hop, req: &Request, resp: &mut Vec<u8>, key: &[u8]) -> DispatchResult<()> {
+        let args = req.typed_args().ok_or(DispatchError::ArgumentRetrieval)?;
+        hop.state().remove(key);
+        let mut map = hop
+            .state()
+            .typed_key::<Map>(key)
+            .ok_or(DispatchError::WrongType)?;
+
+        response::write_map(resp, &args);
+
+        *map = args;
+
+        Ok(())
+    }
+
+    fn set(hop: &Hop, req: &Request, resp: &mut Vec<u8>, key: &[u8]) -> DispatchResult<()> {
+        let args = req.typed_args().ok_or(DispatchError::ArgumentRetrieval)?;
+        hop.state().remove(key);
+        let mut set = hop
+            .state()
+            .typed_key::<SetObject>(key)
+            .ok_or(DispatchError::WrongType)?;
+
+        response::write_set(resp, &args);
+
+        *set = args;
+
+        Ok(())
+    }
+
+    fn string(hop: &Hop, req: &Request, resp: &mut Vec<u8>, key: &[u8]) -> DispatchResult<()> {
+        let arg = req
+            .typed_arg::<&str>(1)
+            .ok_or(DispatchError::ArgumentRetrieval)?;
+        hop.state().remove(key);
+        let mut string = hop
+            .state()
+            .typed_key::<Str>(key)
+            .ok_or(DispatchError::WrongType)?;
+
+        *string = arg.to_owned();
+
+        response::write_str(resp, arg);
+
+        Ok(())
+    }
+}
+
+impl Dispatch for Set {
+    fn dispatch(hop: &Hop, req: &Request, resp: &mut Vec<u8>) -> DispatchResult<()> {
+        let key = req.key().ok_or(DispatchError::KeyUnspecified)?;
+
+        // All types require at least one argument, so let's do that check here.
+        if req.arg(1).is_none() {
+            return Err(DispatchError::ArgumentRetrieval);
+        }
+
+        let key_type = req
+            .key_type()
+            .unwrap_or_else(|| hop.state().key(key, Value::bytes).value().kind());
+
+        match key_type {
+            KeyType::Bytes => Self::bytes(hop, req, resp, key),
+            KeyType::Boolean => Self::boolean(hop, req, resp, key),
+            KeyType::Float => Self::float(hop, req, resp, key),
+            KeyType::Integer => Self::integer(hop, req, resp, key),
+            KeyType::List => Self::list(hop, req, resp, key),
+            KeyType::Map => Self::map(hop, req, resp, key),
+            KeyType::Set => Self::set(hop, req, resp, key),
+            KeyType::String => Self::string(hop, req, resp, key),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Set;
+    use crate::{
+        command::{CommandId, Dispatch, DispatchError, Request, Response},
+        state::{
+            object::{Boolean, Bytes, Float, Integer, List, Map, Set as SetObject, Str},
+            KeyType,
+        },
+        Hop,
+    };
+    use alloc::vec::Vec;
+
+    #[test]
+    fn test_types_no_arg() {
+        let hop = Hop::new();
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        let mut resp = Vec::new();
+
+        let types = [
+            KeyType::Boolean,
+            KeyType::Bytes,
+            KeyType::Float,
+            KeyType::Integer,
+            KeyType::List,
+            KeyType::Map,
+            KeyType::Set,
+            KeyType::String,
+        ];
+
+        for key_type in &types {
+            let req = Request::new_with_type(CommandId::Set, Some(args.clone()), *key_type);
+
+            assert_eq!(
+                Set::dispatch(&hop, &req, &mut resp).unwrap_err(),
+                DispatchError::ArgumentRetrieval,
+            );
+
+            resp.clear();
+        }
+    }
+
+    #[test]
+    fn test_bool() {
+        let hop = Hop::new();
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        args.push([1].to_vec());
+        let req = Request::new_with_type(CommandId::Set, Some(args), KeyType::Boolean);
+        let mut resp = Vec::new();
+
+        assert!(Set::dispatch(&hop, &req, &mut resp).is_ok());
+        assert_eq!(resp, Response::from(true).as_bytes());
+        assert!(hop.state().typed_key::<Boolean>(b"foo").as_deref() == Some(&true));
+    }
+
+    #[test]
+    fn test_bytes() {
+        let hop = Hop::new();
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        args.push(b"bar baz".to_vec());
+        let req = Request::new_with_type(CommandId::Set, Some(args), KeyType::Bytes);
+        let mut resp = Vec::new();
+
+        assert!(Set::dispatch(&hop, &req, &mut resp).is_ok());
+        assert_eq!(resp, Response::from(b"bar baz".to_vec()).as_bytes());
+        assert!(hop.state().typed_key::<Bytes>(b"foo").as_deref() == Some(&b"bar baz".to_vec()));
+    }
+
+    #[test]
+    fn test_float() {
+        let hop = Hop::new();
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        args.push(2f64.to_be_bytes().to_vec());
+        let req = Request::new_with_type(CommandId::Set, Some(args), KeyType::Float);
+        let mut resp = Vec::new();
+
+        assert!(Set::dispatch(&hop, &req, &mut resp).is_ok());
+        assert_eq!(resp, Response::from(2f64).as_bytes());
+        assert!(hop.state().typed_key::<Float>(b"foo").as_deref() == Some(&2f64));
+    }
+
+    #[test]
+    fn test_int() {
+        let hop = Hop::new();
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        args.push(2i64.to_be_bytes().to_vec());
+        let req = Request::new_with_type(CommandId::Set, Some(args), KeyType::Integer);
+        let mut resp = Vec::new();
+
+        assert!(Set::dispatch(&hop, &req, &mut resp).is_ok());
+        assert_eq!(resp, Response::from(2i64).as_bytes());
+        assert!(hop.state().typed_key::<Integer>(b"foo").as_deref() == Some(&2));
+    }
+
+    #[test]
+    fn test_list_three_entries() {
+        let hop = Hop::new();
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        args.push(b"value1".to_vec());
+        args.push(b"value2".to_vec());
+        args.push(b"value2".to_vec());
+        let req = Request::new_with_type(CommandId::Set, Some(args), KeyType::List);
+        let mut resp = Vec::new();
+
+        assert!(Set::dispatch(&hop, &req, &mut resp).is_ok());
+        assert!(
+            hop.state()
+                .typed_key::<List>(b"foo")
+                .as_deref()
+                .map(|x| x.len())
+                == Some(3)
+        );
+    }
+
+    #[test]
+    fn test_map_two_entries() {
+        let hop = Hop::new();
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        args.push(b"key1".to_vec());
+        args.push(b"value1".to_vec());
+        args.push(b"key2".to_vec());
+        args.push(b"value2".to_vec());
+        let req = Request::new_with_type(CommandId::Set, Some(args), KeyType::Map);
+        let mut resp = Vec::new();
+
+        assert!(Set::dispatch(&hop, &req, &mut resp).is_ok());
+        assert!(
+            hop.state()
+                .typed_key::<Map>(b"foo")
+                .as_deref()
+                .map(|x| x.len())
+                == Some(2)
+        );
+    }
+
+    #[test]
+    fn test_set_two_entries() {
+        let hop = Hop::new();
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        args.push(b"value1".to_vec());
+        args.push(b"value2".to_vec());
+        let req = Request::new_with_type(CommandId::Set, Some(args), KeyType::Set);
+        let mut resp = Vec::new();
+
+        assert!(Set::dispatch(&hop, &req, &mut resp).is_ok());
+        assert!(
+            hop.state()
+                .typed_key::<SetObject>(b"foo")
+                .as_deref()
+                .map(|x| x.len())
+                == Some(2)
+        );
+    }
+
+    #[test]
+    fn test_str() {
+        let hop = Hop::new();
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        args.push("bar".as_bytes().to_vec());
+        let req = Request::new_with_type(CommandId::Set, Some(args), KeyType::String);
+        let mut resp = Vec::new();
+
+        assert!(Set::dispatch(&hop, &req, &mut resp).is_ok());
+        assert_eq!(resp, Response::from("bar".to_owned()).as_bytes());
+        assert!(hop.state().typed_key::<Str>(b"foo").as_deref() == Some(&"bar".to_owned()));
+    }
+}

--- a/engine/src/command/request/mod.rs
+++ b/engine/src/command/request/mod.rs
@@ -3,12 +3,91 @@ mod context;
 pub use context::{Context, ParseError};
 
 use super::CommandId;
-use crate::state::KeyType;
-use alloc::vec::{Drain, Vec};
+use crate::state::{KeyType, Value};
+use alloc::{
+    borrow::ToOwned,
+    vec::{Drain, Vec},
+};
 use core::{
+    convert::TryInto,
     ops::{Bound, RangeBounds},
     slice::SliceIndex,
+    str,
 };
+use dashmap::{DashMap, DashSet};
+
+pub trait Argument<'a> {
+    fn convert(bytes: &'a [u8]) -> Option<Self>
+    where
+        Self: Sized;
+}
+
+pub trait MultiArgument<'a> {
+    fn convert(arguments: &'a [Vec<u8>]) -> Option<Self>
+    where
+        Self: Sized;
+}
+
+impl<'a> Argument<'a> for &'a [u8] {
+    fn convert(bytes: &'a [u8]) -> Option<Self> {
+        Some(bytes)
+    }
+}
+
+impl Argument<'_> for bool {
+    fn convert(bytes: &[u8]) -> Option<Self> {
+        let byte = bytes.first()?;
+
+        Some(*byte > 0)
+    }
+}
+
+impl Argument<'_> for f64 {
+    fn convert(bytes: &[u8]) -> Option<Self> {
+        let arr = bytes.get(..8)?.try_into().ok()?;
+
+        Some(f64::from_be_bytes(arr))
+    }
+}
+
+impl Argument<'_> for i64 {
+    fn convert(bytes: &[u8]) -> Option<Self> {
+        let arr = bytes.get(..8)?.try_into().ok()?;
+
+        Some(i64::from_be_bytes(arr))
+    }
+}
+
+impl MultiArgument<'_> for DashMap<Vec<u8>, Vec<u8>> {
+    fn convert(arguments: &[Vec<u8>]) -> Option<Self> {
+        let map = DashMap::new();
+        let mut args = arguments.iter();
+
+        while let (Some(k), Some(v)) = (args.next(), args.next()) {
+            map.insert(k.to_owned(), v.to_owned());
+        }
+
+        Some(map)
+    }
+}
+
+impl MultiArgument<'_> for DashSet<Vec<u8>> {
+    fn convert(arguments: &[Vec<u8>]) -> Option<Self> {
+        let set = DashSet::new();
+
+        for argument in arguments {
+            set.insert(argument.to_owned());
+        }
+
+        Some(set)
+    }
+}
+
+impl<'a> Argument<'a> for &'a str {
+    fn convert(bytes: &'a [u8]) -> Option<Self> {
+        str::from_utf8(bytes).ok()
+    }
+}
 
 #[derive(Debug)]
 pub struct Request {
@@ -38,12 +117,25 @@ impl Request {
         self.args.as_ref()?.get(index)
     }
 
+    pub fn typed_args<'a, T: MultiArgument<'a>>(&'a self) -> Option<T> {
+        let args = self.args.as_ref()?;
+
+        T::convert(args.get(1..)?)
+    }
+
     pub fn arg(&self, idx: usize) -> Option<&[u8]> {
         self.args.as_ref()?.get(idx).map(AsRef::as_ref)
     }
 
     pub fn arg_count(&self) -> usize {
         self.args.as_ref().map(|args| args.len()).unwrap_or(0)
+    }
+
+    pub fn typed_arg<'a, T: Argument<'a>>(&'a self, index: usize) -> Option<T> {
+        let args = self.args.as_ref()?;
+        let arg = args.get(index)?;
+
+        T::convert(arg)
     }
 
     pub fn take_args(&mut self, range: impl RangeBounds<usize>) -> Option<Drain<'_, Vec<u8>>> {
@@ -123,6 +215,37 @@ impl Request {
         }
 
         vec
+    }
+}
+
+pub fn write_value_to_args(value: Value, to: &mut Vec<Vec<u8>>) {
+    match value {
+        Value::Boolean(bool) => {
+            let mut buf = Vec::with_capacity(1);
+            buf.push(bool as u8);
+
+            to.push(buf);
+        }
+        Value::Bytes(bytes) => to.push(bytes),
+        Value::Float(float) => to.push(float.to_be_bytes().to_vec()),
+        Value::Integer(int) => to.push(int.to_be_bytes().to_vec()),
+        Value::List(list) => {
+            for item in list {
+                to.push(item);
+            }
+        }
+        Value::Map(map) => {
+            for (k, v) in map.into_iter() {
+                to.push(k);
+                to.push(v);
+            }
+        }
+        Value::Set(set) => {
+            for item in set {
+                to.push(item);
+            }
+        }
+        Value::String(string) => to.push(string.into_bytes()),
     }
 }
 

--- a/engine/src/hop.rs
+++ b/engine/src/hop.rs
@@ -178,6 +178,7 @@ impl Hop {
             CommandId::Increment => Increment::dispatch(self, req, res),
             CommandId::IncrementBy => IncrementBy::dispatch(self, req, res),
             CommandId::Rename => Rename::dispatch(self, req, res),
+            CommandId::Set => Set::dispatch(self, req, res),
             CommandId::Stats => Stats::dispatch(self, req, res),
             CommandId::Length => Length::dispatch(self, req, res),
         };

--- a/engine/src/state/value.rs
+++ b/engine/src/state/value.rs
@@ -61,11 +61,72 @@ impl Value {
     }
 }
 
+impl From<bool> for Value {
+    fn from(value: bool) -> Self {
+        Self::Boolean(value)
+    }
+}
+
+impl From<Vec<u8>> for Value {
+    fn from(value: Vec<u8>) -> Self {
+        Self::Bytes(value)
+    }
+}
+
+impl From<f64> for Value {
+    fn from(value: f64) -> Self {
+        Self::Float(value)
+    }
+}
+
+impl From<i64> for Value {
+    fn from(value: i64) -> Self {
+        Self::Integer(value)
+    }
+}
+
+impl From<Vec<Vec<u8>>> for Value {
+    fn from(value: Vec<Vec<u8>>) -> Self {
+        Self::List(value)
+    }
+}
+
+impl From<DashMap<Vec<u8>, Vec<u8>>> for Value {
+    fn from(value: DashMap<Vec<u8>, Vec<u8>>) -> Self {
+        Self::Map(value)
+    }
+}
+
+impl From<DashSet<Vec<u8>>> for Value {
+    fn from(value: DashSet<Vec<u8>>) -> Self {
+        Self::Set(value)
+    }
+}
+
+impl From<String> for Value {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Value;
+    use alloc::{string::String, vec::Vec};
     use core::fmt::Debug;
+    use dashmap::{DashMap, DashSet};
     use static_assertions::assert_impl_all;
 
-    assert_impl_all!(Value: Debug);
+    assert_impl_all!(
+        Value: Debug,
+        From<bool>,
+        From<Vec<u8>>,
+        From<f64>,
+        From<i64>,
+        From<Vec<Vec<u8>>>,
+        From<DashMap<Vec<u8>, Vec<u8>>>,
+        From<Vec<u8>>,
+        From<DashSet<Vec<u8>>>,
+        From<String>,
+    );
 }


### PR DESCRIPTION
Add the `set` command, which will set - and possibly over-ride - an
existing key's value.

Command support has been added to the engine and client, but not to the
CLI. The CLI needs additional parsing work to make commands like this
possible.

(future) CLI examples:

```
> set foo:bool true
true
> set foo:int 123
123
> set foo:list 123 456
123
456
```

An example using the client:

```rust
use hop::Client;

let client = Client::memory();

// set a bool
client.set("foo").bool(true).await?;

// set an integer
client.set("foo").int(123).await?;
```

This PR is a part of #6.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>