### PR TITLE
engine: add 'is' command

### DIFF
--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -29,6 +29,12 @@ pub trait Backend {
 
     async fn increment(&self, key: &[u8], key_type: Option<KeyType>) -> Result<i64, Self::Error>;
 
+    async fn is<T: IntoIterator<Item = U> + Send, U: AsRef<[u8]> + Send>(
+        &self,
+        key_type: KeyType,
+        keys: T,
+    ) -> Result<bool, Self::Error>;
+
     async fn rename(&self, from: &[u8], to: &[u8]) -> Result<Vec<u8>, Self::Error>;
 
     async fn set<T: Into<Value> + Send>(&self, key: &[u8], value: T) -> Result<Value, Self::Error>;

--- a/client/src/request/mod.rs
+++ b/client/src/request/mod.rs
@@ -1,4 +1,5 @@
 pub mod exists;
+pub mod is;
 pub mod set;
 
 mod decrement;
@@ -14,11 +15,34 @@ pub use self::{
     echo::Echo,
     exists::{Exists, ExistsConfigured},
     increment::Increment,
+    is::Is,
     rename::Rename,
     set::{SetBytes, SetUnconfigured},
     stats::Stats,
 };
 
-use std::{future::Future, pin::Pin};
+use core::{
+    fmt::{Display, Formatter, Result as FmtResult},
+    future::Future,
+    pin::Pin,
+};
+use std::error::Error;
 
 type MaybeInFlightFuture<'a, Ok, Err> = Option<Pin<Box<dyn Future<Output = Result<Ok, Err>> + 'a>>>;
+
+#[derive(Clone, Debug)]
+pub enum CommandConfigurationError {
+    NoKeys,
+    TooManyKeys,
+}
+
+impl Display for CommandConfigurationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::NoKeys => f.write_str("no keys were provided"),
+            Self::TooManyKeys => f.write_str("too many keys were provided"),
+        }
+    }
+}
+
+impl Error for CommandConfigurationError {}

--- a/engine/src/command/command_id.rs
+++ b/engine/src/command/command_id.rs
@@ -24,6 +24,7 @@ pub enum CommandId {
     Set = 10,
     Delete = 12,
     Exists = 13,
+    Is = 14,
     Rename = 15,
     Append = 20,
     Length = 21,
@@ -43,6 +44,7 @@ impl CommandId {
             Exists => Multiple,
             Increment => None,
             IncrementBy => One,
+            Is => Multiple,
             Decrement => None,
             DecrementBy => One,
             Length => One,
@@ -75,6 +77,7 @@ impl CommandId {
             Self::Exists => "exists",
             Self::IncrementBy => "increment:by",
             Self::Increment => "increment",
+            Self::Is => "is",
             Self::Length => "length",
             Self::Rename => "rename",
             Self::Set => "set",
@@ -102,6 +105,7 @@ impl FromStr for CommandId {
             "exists" => Self::Exists,
             "increment:by" => Self::IncrementBy,
             "increment" => Self::Increment,
+            "is" => Self::Is,
             "length" => Self::Length,
             "rename" => Self::Rename,
             "set" => Self::Set,
@@ -123,6 +127,7 @@ impl TryFrom<u8> for CommandId {
             10 => Self::Set,
             12 => Self::Delete,
             13 => Self::Exists,
+            14 => Self::Is,
             15 => Self::Rename,
             20 => Self::Append,
             21 => Self::Length,
@@ -191,6 +196,7 @@ mod tests {
             CommandId::Increment,
             CommandId::from_str("increment").unwrap()
         );
+        assert_eq!(CommandId::Is, CommandId::from_str("is").unwrap());
         assert_eq!(CommandId::Length, CommandId::from_str("length").unwrap());
         assert_eq!(CommandId::Rename, CommandId::from_str("rename").unwrap());
         assert_eq!(CommandId::Set, CommandId::from_str("set").unwrap());
@@ -207,6 +213,7 @@ mod tests {
         assert_eq!(CommandId::Exists, CommandId::try_from(13).unwrap());
         assert_eq!(CommandId::IncrementBy, CommandId::try_from(2).unwrap());
         assert_eq!(CommandId::Increment, CommandId::try_from(0).unwrap());
+        assert_eq!(CommandId::Is, CommandId::from_str("is").unwrap());
         assert_eq!(CommandId::Length, CommandId::try_from(21).unwrap());
         assert_eq!(CommandId::Rename, CommandId::try_from(15).unwrap());
         assert_eq!(CommandId::Set, CommandId::try_from(10).unwrap());
@@ -223,6 +230,7 @@ mod tests {
         assert_eq!("exists", CommandId::Exists.name());
         assert_eq!("increment:by", CommandId::IncrementBy.name());
         assert_eq!("increment", CommandId::Increment.name());
+        assert_eq!("is", CommandId::Is.name());
         assert_eq!("length", CommandId::Length.name());
         assert_eq!("rename", CommandId::Rename.name());
         assert_eq!("set", CommandId::Set.name());

--- a/engine/src/command/error.rs
+++ b/engine/src/command/error.rs
@@ -15,6 +15,7 @@ pub enum Error {
     KeyTypeUnexpected = 3,
     PreconditionFailed = 4,
     KeyNonexistent = 5,
+    KeyTypeRequired = 6,
 }
 
 impl Display for Error {
@@ -23,6 +24,7 @@ impl Display for Error {
             Self::ArgumentRetrieval => f.write_str("couldn't retrieve required argument"),
             Self::KeyUnspecified => f.write_str("the key wasn't specified"),
             Self::KeyNonexistent => f.write_str("the specified key does not exist"),
+            Self::KeyTypeRequired => f.write_str("a key type is required to be specified"),
             Self::KeyTypeUnexpected => f.write_str("didn't expect a specified request key type"),
             Self::PreconditionFailed => f.write_str("a precondition for the command failed"),
             Self::WrongType => f.write_str("the key has the wrong type"),
@@ -41,6 +43,7 @@ impl TryFrom<u8> for Error {
             3 => Self::KeyTypeUnexpected,
             4 => Self::PreconditionFailed,
             5 => Self::KeyNonexistent,
+            6 => Self::KeyTypeRequired,
             _ => return Err(()),
         })
     }
@@ -76,6 +79,7 @@ mod tests {
             Error::KeyNonexistent,
             Error::KeyTypeUnexpected,
             Error::PreconditionFailed,
+            Error::KeyTypeRequired,
         ];
 
         for variant in variants {

--- a/engine/src/command/impl/is.rs
+++ b/engine/src/command/impl/is.rs
@@ -1,0 +1,109 @@
+use super::super::{response, Dispatch, DispatchError, DispatchResult, Request};
+use crate::Hop;
+use alloc::vec::Vec;
+
+pub struct Is;
+
+impl Dispatch for Is {
+    fn dispatch(hop: &Hop, req: &Request, resp: &mut Vec<u8>) -> DispatchResult<()> {
+        let key_type = req
+            .key_type()
+            .ok_or_else(|| DispatchError::KeyTypeRequired)?;
+        let args = req.args(..).ok_or(DispatchError::ArgumentRetrieval)?;
+        let state = hop.state();
+
+        let all = args.iter().all(|key| match state.key_ref(key) {
+            Some(value) => value.value().kind() == key_type,
+            None => false,
+        });
+
+        response::write_bool(resp, all);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Is;
+    use crate::{
+        command::{CommandId, Dispatch, DispatchError, Request, Response},
+        state::{KeyType, Value},
+        Hop,
+    };
+    use alloc::vec::Vec;
+
+    #[test]
+    fn test_one_arg() {
+        let hop = Hop::new();
+        let mut args = Vec::new();
+        hop.state().key_or_insert_with(b"foo", Value::string);
+        args.push(b"foo".to_vec());
+
+        let req = Request::new_with_type(CommandId::Is, Some(args), KeyType::String);
+        let mut resp = Vec::new();
+
+        assert!(Is::dispatch(&hop, &req, &mut resp).is_ok());
+        assert_eq!(resp, Response::from(true).as_bytes());
+    }
+
+    #[test]
+    fn test_two_args() {
+        let hop = Hop::new();
+        let mut args = Vec::new();
+        hop.state().key_or_insert_with(b"foo", Value::string);
+        args.push(b"foo".to_vec());
+        hop.state().key_or_insert_with(b"bar", Value::string);
+        args.push(b"bar".to_vec());
+
+        let req = Request::new_with_type(CommandId::Is, Some(args), KeyType::String);
+        let mut resp = Vec::new();
+
+        assert!(Is::dispatch(&hop, &req, &mut resp).is_ok());
+        assert_eq!(resp, Response::from(true).as_bytes());
+    }
+
+    #[test]
+    fn test_two_mismatched() {
+        let hop = Hop::new();
+        let mut args = Vec::new();
+        hop.state().key_or_insert_with(b"foo", Value::string);
+        args.push(b"foo".to_vec());
+        hop.state().key_or_insert_with(b"bar", Value::integer);
+        args.push(b"bar".to_vec());
+
+        let req = Request::new_with_type(CommandId::Is, Some(args), KeyType::String);
+        let mut resp = Vec::new();
+
+        assert!(Is::dispatch(&hop, &req, &mut resp).is_ok());
+        assert_eq!(resp, Response::from(false).as_bytes());
+    }
+
+    #[test]
+    fn test_no_arguments() {
+        let hop = Hop::new();
+
+        let req = Request::new_with_type(CommandId::Is, None, KeyType::Bytes);
+        let mut resp = Vec::new();
+
+        assert!(matches!(
+            Is::dispatch(&hop, &req, &mut resp),
+            Err(DispatchError::ArgumentRetrieval)
+        ));
+    }
+
+    #[test]
+    fn test_key_type_unspecified() {
+        let hop = Hop::new();
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+
+        let req = Request::new(CommandId::Is, Some(args));
+        let mut resp = Vec::new();
+
+        assert!(matches!(
+            Is::dispatch(&hop, &req, &mut resp),
+            Err(DispatchError::KeyTypeRequired)
+        ));
+    }
+}

--- a/engine/src/command/impl/length.rs
+++ b/engine/src/command/impl/length.rs
@@ -55,7 +55,11 @@ impl Dispatch for Length {
             Some(KeyType::String) => Self::string(hop, key, resp),
             Some(_) => Err(DispatchError::WrongType),
             None => {
-                let kind = hop.state().key(key, Value::bytes).value().kind();
+                let kind = hop
+                    .state()
+                    .key_or_insert_with(key, Value::bytes)
+                    .value()
+                    .kind();
 
                 match kind {
                     KeyType::Bytes => Self::bytes(hop, key, resp),

--- a/engine/src/command/impl/mod.rs
+++ b/engine/src/command/impl/mod.rs
@@ -6,6 +6,7 @@ mod echo;
 mod exists;
 mod increment;
 mod increment_by;
+mod is;
 mod length;
 mod rename;
 mod set;
@@ -13,6 +14,6 @@ mod stats;
 
 pub use self::{
     append::Append, decrement::Decrement, decrement_by::DecrementBy, delete::Delete, echo::Echo,
-    exists::Exists, increment::Increment, increment_by::IncrementBy, length::Length,
+    exists::Exists, increment::Increment, increment_by::IncrementBy, is::Is, length::Length,
     rename::Rename, set::Set, stats::Stats,
 };

--- a/engine/src/command/impl/set.rs
+++ b/engine/src/command/impl/set.rs
@@ -145,9 +145,12 @@ impl Dispatch for Set {
             return Err(DispatchError::ArgumentRetrieval);
         }
 
-        let key_type = req
-            .key_type()
-            .unwrap_or_else(|| hop.state().key(key, Value::bytes).value().kind());
+        let key_type = req.key_type().unwrap_or_else(|| {
+            hop.state()
+                .key_or_insert_with(key, Value::bytes)
+                .value()
+                .kind()
+        });
 
         match key_type {
             KeyType::Bytes => Self::bytes(hop, req, resp, key),

--- a/engine/src/hop.rs
+++ b/engine/src/hop.rs
@@ -177,6 +177,7 @@ impl Hop {
             CommandId::Exists => Exists::dispatch(self, req, res),
             CommandId::Increment => Increment::dispatch(self, req, res),
             CommandId::IncrementBy => IncrementBy::dispatch(self, req, res),
+            CommandId::Is => Is::dispatch(self, req, res),
             CommandId::Rename => Rename::dispatch(self, req, res),
             CommandId::Set => Set::dispatch(self, req, res),
             CommandId::Stats => Stats::dispatch(self, req, res),


### PR DESCRIPTION
Add an 'is' command, which can be used to check that one or more keys is
of a certain specified key type. The command returns a boolean. If
*at least* one of the keys does not exist or is not of the specified
type, then `false` is returned. This is short-circuiting.

A potential case is where you have a key "foo" that you *think* is a
string, but you want to verify this, then you'd use the `is` command
with a key type of `String` and an argument of "foo".

If a key type isn't specified, then a `DispatchError::KeyTypeRequired`
error is returned.

If no arguments are provided, then a `DispatchError::ArgumentRetrieval`
error is returned.

For example, the command can be visualised by the CLI:

```
> set:str foo the value
the value
> is:str foo
true
> is:str foo bar
false

```

And also by the client:

```rust
use hop::{Client, KeyType};

let client = Client::memory();

client.set("foo").int(123).await?;

assert!(client.is(KeyType::Integer).key("foo").await?);
```

This pull request does not add CLI support because key types require #33.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>