### PR TITLE
engine/command/response: make list writes generic

### DIFF
--- a/engine/src/command/impl/append.rs
+++ b/engine/src/command/impl/append.rs
@@ -38,7 +38,7 @@ impl Dispatch for Append {
 
                 list.append(&mut args.to_owned());
 
-                response::write_list(resp, &list);
+                response::write_list(resp, list.iter());
             }
             Some(KeyType::String) => {
                 let mut string = hop

--- a/engine/src/command/impl/echo.rs
+++ b/engine/src/command/impl/echo.rs
@@ -8,7 +8,11 @@ impl Dispatch for Echo {
     fn dispatch(_: &Hop, req: &Request, resp: &mut Vec<u8>) -> DispatchResult<()> {
         match req.args(..) {
             Some(args) => response::write_list(resp, args),
-            None => response::write_list(resp, &[]),
+            None => {
+                let empty_slice: &[&[u8]] = &[];
+
+                response::write_list(resp, empty_slice);
+            }
         }
 
         Ok(())


### PR DESCRIPTION
Make the `command::response::write_list` function generic over anything
that can be an iterator that iterates over anything that can be a
reference over a `&[u8]`. This allows for writing lists using values
that aren't simply and only a `&[Vec<u8>]`.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>