### PR TITLE
engine/command: add key type invalid dispatch error

### DIFF
--- a/cli/lib/src/process.rs
+++ b/cli/lib/src/process.rs
@@ -76,6 +76,7 @@ enum InnerProcessError<B: Backend> {
     KeyRequiredMinimum,
     KeySourceRequired,
     KeyTypeDifferent,
+    KeyTypeInvalid,
     KeyTypeRequired,
     KeyTypeUnexpected,
     KeyUnspecified,
@@ -123,6 +124,9 @@ where
         Err(InnerProcessError::KeyTypeDifferent) => {
             "The type of the key is different than specified by the command.".into()
         }
+        Err(InnerProcessError::KeyTypeInvalid) => {
+            "A key type was provided that isn't supported by the command.".into()
+        }
         Err(InnerProcessError::KeyTypeRequired) => {
             "A key type was required but one was not specified.".into()
         }
@@ -157,11 +161,12 @@ where
                 MemoryError::RunningCommand { source } => match source {
                     DispatchError::ArgumentRetrieval => InnerProcessError::TooFewArguments,
                     DispatchError::KeyNonexistent => InnerProcessError::KeyNonexistent,
+                    DispatchError::KeyTypeDifferent => InnerProcessError::KeyTypeDifferent,
+                    DispatchError::KeyTypeInvalid => InnerProcessError::KeyTypeInvalid,
                     DispatchError::KeyTypeRequired => InnerProcessError::KeyTypeRequired,
                     DispatchError::KeyTypeUnexpected => InnerProcessError::KeyTypeUnexpected,
                     DispatchError::KeyUnspecified => InnerProcessError::KeyUnspecified,
                     DispatchError::PreconditionFailed => InnerProcessError::PreconditionFailed,
-                    DispatchError::WrongType => InnerProcessError::KeyTypeDifferent,
                 },
             }
         }

--- a/engine/src/command/error.rs
+++ b/engine/src/command/error.rs
@@ -11,23 +11,27 @@ pub type Result<T, E = Error> = CoreResult<T, E>;
 pub enum Error {
     ArgumentRetrieval = 0,
     KeyUnspecified = 1,
-    WrongType = 2,
+    KeyTypeDifferent = 2,
     KeyTypeUnexpected = 3,
     PreconditionFailed = 4,
     KeyNonexistent = 5,
     KeyTypeRequired = 6,
+    KeyTypeInvalid = 7,
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             Self::ArgumentRetrieval => f.write_str("couldn't retrieve required argument"),
-            Self::KeyUnspecified => f.write_str("the key wasn't specified"),
             Self::KeyNonexistent => f.write_str("the specified key does not exist"),
+            Self::KeyTypeDifferent => f.write_str("the key has a different type than required"),
+            Self::KeyTypeInvalid => {
+                f.write_str("the specified key type is not supported by the command")
+            }
             Self::KeyTypeRequired => f.write_str("a key type is required to be specified"),
             Self::KeyTypeUnexpected => f.write_str("didn't expect a specified request key type"),
+            Self::KeyUnspecified => f.write_str("the key wasn't specified"),
             Self::PreconditionFailed => f.write_str("a precondition for the command failed"),
-            Self::WrongType => f.write_str("the key has the wrong type"),
         }
     }
 }
@@ -39,11 +43,12 @@ impl TryFrom<u8> for Error {
         Ok(match value {
             0 => Self::ArgumentRetrieval,
             1 => Self::KeyUnspecified,
-            2 => Self::WrongType,
+            2 => Self::KeyTypeDifferent,
             3 => Self::KeyTypeUnexpected,
             4 => Self::PreconditionFailed,
             5 => Self::KeyNonexistent,
             6 => Self::KeyTypeRequired,
+            7 => Self::KeyTypeInvalid,
             _ => return Err(()),
         })
     }
@@ -74,12 +79,13 @@ mod tests {
     fn test_error_try_from_u8() {
         let variants = &[
             Error::ArgumentRetrieval,
-            Error::KeyUnspecified,
-            Error::WrongType,
             Error::KeyNonexistent,
-            Error::KeyTypeUnexpected,
-            Error::PreconditionFailed,
+            Error::KeyTypeDifferent,
+            Error::KeyTypeInvalid,
             Error::KeyTypeRequired,
+            Error::KeyTypeUnexpected,
+            Error::KeyUnspecified,
+            Error::PreconditionFailed,
         ];
 
         for variant in variants {

--- a/engine/src/command/impl/append.rs
+++ b/engine/src/command/impl/append.rs
@@ -22,7 +22,7 @@ impl Dispatch for Append {
                 let mut bytes = hop
                     .state()
                     .typed_key::<Bytes>(key)
-                    .ok_or(DispatchError::WrongType)?;
+                    .ok_or(DispatchError::KeyTypeDifferent)?;
 
                 for arg in args {
                     bytes.extend_from_slice(arg);
@@ -34,7 +34,7 @@ impl Dispatch for Append {
                 let mut list = hop
                     .state()
                     .typed_key::<List>(key)
-                    .ok_or(DispatchError::WrongType)?;
+                    .ok_or(DispatchError::KeyTypeDifferent)?;
 
                 list.append(&mut args.to_owned());
 
@@ -44,7 +44,7 @@ impl Dispatch for Append {
                 let mut string = hop
                     .state()
                     .typed_key::<Str>(key)
-                    .ok_or(DispatchError::WrongType)?;
+                    .ok_or(DispatchError::KeyTypeDifferent)?;
 
                 for arg in args {
                     if let Ok(arg) = str::from_utf8(arg) {
@@ -54,7 +54,7 @@ impl Dispatch for Append {
 
                 response::write_str(resp, &string);
             }
-            Some(_) => return Err(DispatchError::WrongType),
+            Some(_) => return Err(DispatchError::KeyTypeDifferent),
         }
 
         Ok(())

--- a/engine/src/command/impl/decrement_by.rs
+++ b/engine/src/command/impl/decrement_by.rs
@@ -39,7 +39,7 @@ impl DecrementBy {
 
                 response::write_float(resp, *float);
             }
-            Some(_) => return Err(DispatchError::WrongType),
+            Some(_) => return Err(DispatchError::KeyTypeInvalid),
         }
 
         Ok(())

--- a/engine/src/command/impl/increment_by.rs
+++ b/engine/src/command/impl/increment_by.rs
@@ -39,7 +39,7 @@ impl IncrementBy {
 
                 response::write_float(resp, *float)
             }
-            Some(_) => return Err(DispatchError::WrongType),
+            Some(_) => return Err(DispatchError::KeyTypeInvalid),
         }
 
         Ok(())

--- a/engine/src/command/impl/length.rs
+++ b/engine/src/command/impl/length.rs
@@ -14,7 +14,7 @@ impl Length {
     fn bytes(hop: &Hop, key: &[u8], resp: &mut Vec<u8>) -> DispatchResult<()> {
         let bytes = match hop.state().typed_key::<Bytes>(key) {
             Some(bytes) => bytes,
-            None => return Err(DispatchError::WrongType),
+            None => return Err(DispatchError::KeyTypeDifferent),
         };
 
         response::write_int(resp, bytes.len() as i64);
@@ -25,7 +25,7 @@ impl Length {
     fn list(hop: &Hop, key: &[u8], resp: &mut Vec<u8>) -> DispatchResult<()> {
         let list = match hop.state().typed_key::<List>(key) {
             Some(list) => list,
-            None => return Err(DispatchError::WrongType),
+            None => return Err(DispatchError::KeyTypeDifferent),
         };
 
         response::write_int(resp, list.len() as i64);
@@ -36,7 +36,7 @@ impl Length {
     fn string(hop: &Hop, key: &[u8], resp: &mut Vec<u8>) -> DispatchResult<()> {
         let string = match hop.state().typed_key::<Str>(key) {
             Some(string) => string,
-            None => return Err(DispatchError::WrongType),
+            None => return Err(DispatchError::KeyTypeDifferent),
         };
 
         response::write_int(resp, string.chars().count() as i64);
@@ -53,7 +53,7 @@ impl Dispatch for Length {
             Some(KeyType::Bytes) => Self::bytes(hop, key, resp),
             Some(KeyType::List) => Self::list(hop, key, resp),
             Some(KeyType::String) => Self::string(hop, key, resp),
-            Some(_) => Err(DispatchError::WrongType),
+            Some(_) => Err(DispatchError::KeyTypeInvalid),
             None => {
                 let kind = hop
                     .state()
@@ -65,7 +65,7 @@ impl Dispatch for Length {
                     KeyType::Bytes => Self::bytes(hop, key, resp),
                     KeyType::List => Self::list(hop, key, resp),
                     KeyType::String => Self::string(hop, key, resp),
-                    _ => Err(DispatchError::WrongType),
+                    _ => Err(DispatchError::KeyTypeInvalid),
                 }
             }
         }
@@ -96,7 +96,7 @@ mod tests {
     }
 
     #[test]
-    fn test_wrong_type() {
+    fn test_invalid_key_type() {
         let hop = Hop::new();
 
         let mut args = Vec::new();
@@ -117,7 +117,7 @@ mod tests {
 
             assert_eq!(
                 Length::dispatch(&hop, &req, &mut resp).unwrap_err(),
-                DispatchError::WrongType
+                DispatchError::KeyTypeInvalid
             );
 
             resp.clear();

--- a/engine/src/command/impl/set.rs
+++ b/engine/src/command/impl/set.rs
@@ -17,7 +17,7 @@ impl Set {
         let mut boolean = hop
             .state()
             .typed_key::<Boolean>(key)
-            .ok_or(DispatchError::WrongType)?;
+            .ok_or(DispatchError::KeyTypeDifferent)?;
 
         *boolean = arg;
 
@@ -34,7 +34,7 @@ impl Set {
         let mut bytes = hop
             .state()
             .typed_key::<Bytes>(key)
-            .ok_or(DispatchError::WrongType)?;
+            .ok_or(DispatchError::KeyTypeDifferent)?;
 
         *bytes = arg.to_vec();
 
@@ -49,7 +49,7 @@ impl Set {
         let mut float = hop
             .state()
             .typed_key::<Float>(key)
-            .ok_or(DispatchError::WrongType)?;
+            .ok_or(DispatchError::KeyTypeDifferent)?;
 
         *float = arg;
 
@@ -64,7 +64,7 @@ impl Set {
         let mut int = hop
             .state()
             .typed_key::<Integer>(key)
-            .ok_or(DispatchError::WrongType)?;
+            .ok_or(DispatchError::KeyTypeDifferent)?;
 
         *int = arg;
 
@@ -79,7 +79,7 @@ impl Set {
         let mut list = hop
             .state()
             .typed_key::<List>(key)
-            .ok_or(DispatchError::WrongType)?;
+            .ok_or(DispatchError::KeyTypeDifferent)?;
 
         *list = args.to_vec();
 
@@ -94,7 +94,7 @@ impl Set {
         let mut map = hop
             .state()
             .typed_key::<Map>(key)
-            .ok_or(DispatchError::WrongType)?;
+            .ok_or(DispatchError::KeyTypeDifferent)?;
 
         response::write_map(resp, &args);
 
@@ -109,7 +109,7 @@ impl Set {
         let mut set = hop
             .state()
             .typed_key::<SetObject>(key)
-            .ok_or(DispatchError::WrongType)?;
+            .ok_or(DispatchError::KeyTypeDifferent)?;
 
         response::write_set(resp, &args);
 
@@ -126,7 +126,7 @@ impl Set {
         let mut string = hop
             .state()
             .typed_key::<Str>(key)
-            .ok_or(DispatchError::WrongType)?;
+            .ok_or(DispatchError::KeyTypeDifferent)?;
 
         *string = arg.to_owned();
 

--- a/engine/src/command/response/context.rs
+++ b/engine/src/command/response/context.rs
@@ -634,7 +634,7 @@ mod tests {
     }
 
     #[test]
-    fn test_req_dispatch_error_wrong_type() {
+    fn test_req_dispatch_error_key_type_different() {
         let mut ctx = Context::new();
         let buf = [
             0,
@@ -642,12 +642,12 @@ mod tests {
             0,
             2,
             ResponseType::DispatchError as u8,
-            DispatchError::WrongType as u8,
+            DispatchError::KeyTypeDifferent as u8,
         ];
         assert!(matches!(
             ctx.feed(&buf),
             Ok(Instruction::Concluded(Response::DispatchError(
-                DispatchError::WrongType
+                DispatchError::KeyTypeDifferent
             )))
         ));
     }


### PR DESCRIPTION
The `DispatchError::WrongType` error was being used for both when the
key type was not supported by a command and when a key's type was
different than the requested key type operation.

To fix this, split the variant into `KeyTypeInvalid` for the former case
and `KeyTypeDifferent` for the latter case. The new variant has error
number 7.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>