### PR TITLE
engine: add 'keys' command

### DIFF
--- a/cli/lib/src/process.rs
+++ b/cli/lib/src/process.rs
@@ -256,6 +256,13 @@ where
 
             Ok(is_type.to_string().into())
         }
+        CommandId::Keys => {
+            let key = req.key().ok_or_else(|| InnerProcessError::KeyUnspecified)?;
+
+            let v = client.keys(key).await.map_err(backend_err)?;
+
+            Ok(print_list(v).into())
+        }
         CommandId::Rename => {
             let from = req
                 .key()
@@ -289,4 +296,11 @@ where
         }
         _ => panic!(),
     }
+}
+
+fn print_list(list: Vec<Vec<u8>>) -> String {
+    list.into_iter()
+        .map(|item| String::from_utf8_lossy(&item).into_owned())
+        .collect::<Vec<_>>()
+        .join("\n")
 }

--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -35,6 +35,8 @@ pub trait Backend {
         keys: T,
     ) -> Result<bool, Self::Error>;
 
+    async fn keys(&self, key: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error>;
+
     async fn rename(&self, from: &[u8], to: &[u8]) -> Result<Vec<u8>, Self::Error>;
 
     async fn set<T: Into<Value> + Send>(&self, key: &[u8], value: T) -> Result<Value, Self::Error>;

--- a/client/src/backend/server.rs
+++ b/client/src/backend/server.rs
@@ -222,6 +222,20 @@ impl Backend for ServerBackend {
         }
     }
 
+    async fn keys(&self, key: &[u8]) -> Result<Vec<Vec<u8>>> {
+        let mut args = Vec::with_capacity(1);
+        args.push(key.to_vec());
+
+        let req = Request::new(CommandId::Keys, Some(args));
+
+        let value = self.send_and_wait(&req.into_bytes()).await?;
+
+        match value {
+            Value::List(list) => Ok(list),
+            _ => Err(Error::BadResponse),
+        }
+    }
+
     async fn rename(&self, from: &[u8], to: &[u8]) -> Result<Vec<u8>> {
         let mut args = Vec::with_capacity(2);
         args.push(from.to_vec());

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -208,6 +208,26 @@ impl<B: Backend> Client<B> {
         Is::new(self.backend(), key_type)
     }
 
+    /// Retrieve a list of the keys of a map.
+    ///
+    /// Returns the list of keys on success.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hop::Client;
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::memory();
+    /// client.set("foo").map([(b"key".to_vec(), b"value".to_vec())].to_vec()).await?;
+    ///
+    /// assert_eq!([b"key".to_vec()].to_vec(), client.keys("foo").await?);
+    /// # Ok(()) }
+    /// ```
+    pub fn keys<K: AsRef<[u8]> + Unpin>(&self, key: K) -> Keys<'_, B, K> {
+        Keys::new(self.backend(), key)
+    }
+
     /// Rename a key to a new key name, if the new key name doesn't already
     /// exist.
     ///

--- a/client/src/request/keys.rs
+++ b/client/src/request/keys.rs
@@ -1,0 +1,40 @@
+use super::MaybeInFlightFuture;
+use crate::Backend;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+pub struct Keys<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, Vec<Vec<u8>>, B::Error>,
+    key: Option<K>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> Keys<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for Keys<'a, B, K> {
+    type Output = Result<Vec<Vec<u8>>, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = { self.backend.take().expect("backend only taken once") };
+            let key = self.key.take().expect("key only taken once");
+
+            self.fut
+                .replace(Box::pin(async move { backend.keys(key.as_ref()).await }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}

--- a/client/src/request/mod.rs
+++ b/client/src/request/mod.rs
@@ -6,6 +6,7 @@ mod decrement;
 mod delete;
 mod echo;
 mod increment;
+mod keys;
 mod rename;
 mod stats;
 
@@ -16,6 +17,7 @@ pub use self::{
     exists::{Exists, ExistsConfigured},
     increment::Increment,
     is::Is,
+    keys::Keys,
     rename::Rename,
     set::{SetBytes, SetUnconfigured},
     stats::Stats,

--- a/engine/src/command/command_id.rs
+++ b/engine/src/command/command_id.rs
@@ -36,6 +36,7 @@ pub enum CommandId {
     Rename = 15,
     Append = 20,
     Length = 21,
+    Keys = 22,
     Echo = 100,
     Stats = 101,
 }
@@ -55,6 +56,7 @@ impl CommandId {
             Increment => None,
             IncrementBy => One,
             Is => None,
+            Keys => None,
             Length => One,
             Rename => None,
             Set => One,
@@ -76,6 +78,7 @@ impl CommandId {
             Increment => One,
             IncrementBy => One,
             Is => Multiple,
+            Keys => One,
             Length => One,
             Rename => Two,
             Set => One,
@@ -101,6 +104,7 @@ impl CommandId {
             Self::IncrementBy => "increment:by",
             Self::Increment => "increment",
             Self::Is => "is",
+            Self::Keys => "keys",
             Self::Length => "length",
             Self::Rename => "rename",
             Self::Set => "set",
@@ -129,6 +133,7 @@ impl FromStr for CommandId {
             "increment:by" => Self::IncrementBy,
             "increment" => Self::Increment,
             "is" => Self::Is,
+            "keys" => Self::Keys,
             "length" => Self::Length,
             "rename" => Self::Rename,
             "set" => Self::Set,
@@ -154,6 +159,7 @@ impl TryFrom<u8> for CommandId {
             15 => Self::Rename,
             20 => Self::Append,
             21 => Self::Length,
+            22 => Self::Keys,
             100 => Self::Echo,
             101 => Self::Stats,
             _ => return Err(InvalidCommandId),
@@ -220,6 +226,7 @@ mod tests {
             CommandId::from_str("increment").unwrap()
         );
         assert_eq!(CommandId::Is, CommandId::from_str("is").unwrap());
+        assert_eq!(CommandId::Keys, CommandId::from_str("keys").unwrap());
         assert_eq!(CommandId::Length, CommandId::from_str("length").unwrap());
         assert_eq!(CommandId::Rename, CommandId::from_str("rename").unwrap());
         assert_eq!(CommandId::Set, CommandId::from_str("set").unwrap());
@@ -236,7 +243,8 @@ mod tests {
         assert_eq!(CommandId::Exists, CommandId::try_from(13).unwrap());
         assert_eq!(CommandId::IncrementBy, CommandId::try_from(2).unwrap());
         assert_eq!(CommandId::Increment, CommandId::try_from(0).unwrap());
-        assert_eq!(CommandId::Is, CommandId::from_str("is").unwrap());
+        assert_eq!(CommandId::Is, CommandId::try_from(14).unwrap());
+        assert_eq!(CommandId::Keys, CommandId::try_from(22).unwrap());
         assert_eq!(CommandId::Length, CommandId::try_from(21).unwrap());
         assert_eq!(CommandId::Rename, CommandId::try_from(15).unwrap());
         assert_eq!(CommandId::Set, CommandId::try_from(10).unwrap());
@@ -254,6 +262,7 @@ mod tests {
         assert_eq!("increment:by", CommandId::IncrementBy.name());
         assert_eq!("increment", CommandId::Increment.name());
         assert_eq!("is", CommandId::Is.name());
+        assert_eq!("keys", CommandId::Keys.name());
         assert_eq!("length", CommandId::Length.name());
         assert_eq!("rename", CommandId::Rename.name());
         assert_eq!("set", CommandId::Set.name());

--- a/engine/src/command/impl/keys.rs
+++ b/engine/src/command/impl/keys.rs
@@ -1,0 +1,114 @@
+use super::super::{response, Dispatch, DispatchError, DispatchResult, Request};
+use crate::{
+    state::{object::Map, KeyType},
+    Hop,
+};
+use alloc::vec::Vec;
+
+pub struct Keys;
+
+impl Keys {
+    fn map(hop: &Hop, key: &[u8], resp: &mut Vec<u8>) -> DispatchResult<()> {
+        let map = hop
+            .state()
+            .typed_key::<Map>(key)
+            .ok_or_else(|| DispatchError::KeyTypeDifferent)?;
+        let iter = map.iter().map(|r| r.key().to_vec());
+
+        response::write_list(resp, iter);
+
+        Ok(())
+    }
+}
+
+impl Dispatch for Keys {
+    fn dispatch(hop: &Hop, req: &Request, resp: &mut Vec<u8>) -> DispatchResult<()> {
+        let key = req.key().ok_or(DispatchError::KeyUnspecified)?;
+
+        match req.key_type() {
+            Some(KeyType::Map) => Self::map(hop, key, resp),
+            Some(_) => Err(DispatchError::KeyTypeInvalid),
+            None => Self::map(hop, key, resp),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Keys;
+    use crate::{
+        command::{CommandId, Dispatch, DispatchError, Request, Response},
+        state::{KeyType, Value},
+        Hop,
+    };
+    use alloc::vec::Vec;
+    use dashmap::DashMap;
+
+    #[test]
+    fn test_map_no_key_type_two_pairs() {
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        let hop = Hop::new();
+        let req = Request::new(CommandId::Keys, Some(args));
+
+        let mut resp = Vec::new();
+
+        let map = DashMap::new();
+        map.insert(b"key1".to_vec(), b"value2".to_vec());
+        map.insert(b"key2".to_vec(), b"value2".to_vec());
+        hop.state().insert(b"foo".to_vec(), Value::Map(map));
+
+        assert!(Keys::dispatch(&hop, &req, &mut resp).is_ok());
+        let expected1 = Response::from([b"key1".to_vec(), b"key2".to_vec()].to_vec()).as_bytes();
+        let expected2 = Response::from([b"key2".to_vec(), b"key1".to_vec()].to_vec()).as_bytes();
+        assert!(resp == expected1 || resp == expected2);
+    }
+
+    #[test]
+    fn test_map_key_type() {
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        let hop = Hop::new();
+        let req = Request::new_with_type(CommandId::Keys, Some(args), KeyType::Map);
+
+        let mut resp = Vec::new();
+
+        let map = DashMap::new();
+        map.insert(b"key".to_vec(), b"value".to_vec());
+        hop.state().insert(b"foo".to_vec(), Value::Map(map));
+
+        assert!(Keys::dispatch(&hop, &req, &mut resp).is_ok());
+        assert_eq!(resp, Response::from([b"key".to_vec()].to_vec()).as_bytes());
+    }
+
+    #[test]
+    fn test_key_type_invalid() {
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        let hop = Hop::new();
+        let req = Request::new_with_type(CommandId::Keys, Some(args), KeyType::Integer);
+
+        let mut resp = Vec::new();
+
+        assert_eq!(
+            DispatchError::KeyTypeInvalid,
+            Keys::dispatch(&hop, &req, &mut resp).unwrap_err()
+        );
+    }
+
+    #[test]
+    fn test_key_type_different() {
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        let hop = Hop::new();
+        let req = Request::new_with_type(CommandId::Keys, Some(args), KeyType::Map);
+
+        let mut resp = Vec::new();
+
+        hop.state().insert(b"foo".to_vec(), Value::Integer(1));
+        assert_eq!(
+            DispatchError::KeyTypeDifferent,
+            Keys::dispatch(&hop, &req, &mut resp).unwrap_err()
+        );
+    }
+}

--- a/engine/src/command/impl/mod.rs
+++ b/engine/src/command/impl/mod.rs
@@ -7,6 +7,7 @@ mod exists;
 mod increment;
 mod increment_by;
 mod is;
+mod keys;
 mod length;
 mod rename;
 mod set;
@@ -14,6 +15,6 @@ mod stats;
 
 pub use self::{
     append::Append, decrement::Decrement, decrement_by::DecrementBy, delete::Delete, echo::Echo,
-    exists::Exists, increment::Increment, increment_by::IncrementBy, is::Is, length::Length,
-    rename::Rename, set::Set, stats::Stats,
+    exists::Exists, increment::Increment, increment_by::IncrementBy, is::Is, keys::Keys,
+    length::Length, rename::Rename, set::Set, stats::Stats,
 };

--- a/engine/src/hop.rs
+++ b/engine/src/hop.rs
@@ -178,6 +178,7 @@ impl Hop {
             CommandId::Increment => Increment::dispatch(self, req, res),
             CommandId::IncrementBy => IncrementBy::dispatch(self, req, res),
             CommandId::Is => Is::dispatch(self, req, res),
+            CommandId::Keys => Keys::dispatch(self, req, res),
             CommandId::Rename => Rename::dispatch(self, req, res),
             CommandId::Set => Set::dispatch(self, req, res),
             CommandId::Stats => Stats::dispatch(self, req, res),


### PR DESCRIPTION
Add the `keys` command, which retrieves a list of the keys of a value.
The only currently supported key type are maps.

CLI example:

```
> set:map foo key1 value1 key2 value2
key1=value1
key2=key2
> keys foo
key1
key2
```

Closes #8.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>