### PR TITLE
engine: add 'type' command

### DIFF
--- a/cli/lib/src/lib.rs
+++ b/cli/lib/src/lib.rs
@@ -5,6 +5,7 @@
 extern crate alloc;
 
 mod parse;
+mod print;
 mod process;
 
 pub use self::{

--- a/cli/lib/src/print.rs
+++ b/cli/lib/src/print.rs
@@ -1,0 +1,14 @@
+use hop_engine::state::KeyType;
+
+pub fn key_type_name(key_type: KeyType) -> &'static str {
+    match key_type {
+        KeyType::Boolean => "bool",
+        KeyType::Bytes => "bytes",
+        KeyType::Float => "float",
+        KeyType::Integer => "int",
+        KeyType::List => "list",
+        KeyType::Map => "map",
+        KeyType::Set => "set",
+        KeyType::String => "str",
+    }
+}

--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -35,6 +35,8 @@ pub trait Backend {
         keys: T,
     ) -> Result<bool, Self::Error>;
 
+    async fn key_type(&self, key: &[u8]) -> Result<KeyType, Self::Error>;
+
     async fn keys(&self, key: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error>;
 
     async fn rename(&self, from: &[u8], to: &[u8]) -> Result<Vec<u8>, Self::Error>;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -208,6 +208,24 @@ impl<B: Backend> Client<B> {
         Is::new(self.backend(), key_type)
     }
 
+    /// Retrieve the type of a key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hop::{Client, KeyType};
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::memory();
+    /// client.set("foo").int(123).await?;
+    ///
+    /// assert_eq!(KeyType::Integer, client.key_type("foo").await?);
+    /// # Ok(()) }
+    /// ```
+    pub fn key_type<K: AsRef<[u8]> + Unpin>(&self, key: K) -> Type<'_, B, K> {
+        Type::new(self.backend(), key)
+    }
+
     /// Retrieve a list of the keys of a map.
     ///
     /// Returns the list of keys on success.

--- a/client/src/request/mod.rs
+++ b/client/src/request/mod.rs
@@ -9,6 +9,7 @@ mod increment;
 mod keys;
 mod rename;
 mod stats;
+mod r#type;
 
 pub use self::{
     decrement::Decrement,
@@ -18,6 +19,7 @@ pub use self::{
     increment::Increment,
     is::Is,
     keys::Keys,
+    r#type::Type,
     rename::Rename,
     set::{SetBytes, SetUnconfigured},
     stats::Stats,

--- a/client/src/request/type.rs
+++ b/client/src/request/type.rs
@@ -1,0 +1,42 @@
+use super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::KeyType;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+pub struct Type<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, KeyType, B::Error>,
+    key: Option<K>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> Type<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for Type<'a, B, K> {
+    type Output = Result<KeyType, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = { self.backend.take().expect("backend only taken once") };
+            let key = self.key.take().expect("key only taken once");
+
+            self.fut.replace(Box::pin(
+                async move { backend.key_type(key.as_ref()).await },
+            ));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}

--- a/engine/src/command/command_id.rs
+++ b/engine/src/command/command_id.rs
@@ -34,6 +34,7 @@ pub enum CommandId {
     Exists = 13,
     Is = 14,
     Rename = 15,
+    Type = 16,
     Append = 20,
     Length = 21,
     Keys = 22,
@@ -61,6 +62,7 @@ impl CommandId {
             Rename => None,
             Set => One,
             Stats => None,
+            Type => None,
         }
     }
 
@@ -83,6 +85,7 @@ impl CommandId {
             Rename => Two,
             Set => One,
             Stats => None,
+            Type => One,
         }
     }
 
@@ -109,6 +112,7 @@ impl CommandId {
             Self::Rename => "rename",
             Self::Set => "set",
             Self::Stats => "stats",
+            Self::Type => "type",
         }
     }
 }
@@ -138,6 +142,7 @@ impl FromStr for CommandId {
             "rename" => Self::Rename,
             "set" => Self::Set,
             "stats" => Self::Stats,
+            "type" => Self::Type,
             _ => return Err(InvalidCommandId),
         })
     }
@@ -157,6 +162,7 @@ impl TryFrom<u8> for CommandId {
             13 => Self::Exists,
             14 => Self::Is,
             15 => Self::Rename,
+            16 => Self::Type,
             20 => Self::Append,
             21 => Self::Length,
             22 => Self::Keys,
@@ -231,6 +237,7 @@ mod tests {
         assert_eq!(CommandId::Rename, CommandId::from_str("rename").unwrap());
         assert_eq!(CommandId::Set, CommandId::from_str("set").unwrap());
         assert_eq!(CommandId::Stats, CommandId::from_str("stats").unwrap());
+        assert_eq!(CommandId::Type, CommandId::from_str("type").unwrap());
     }
 
     #[test]
@@ -249,6 +256,7 @@ mod tests {
         assert_eq!(CommandId::Rename, CommandId::try_from(15).unwrap());
         assert_eq!(CommandId::Set, CommandId::try_from(10).unwrap());
         assert_eq!(CommandId::Stats, CommandId::try_from(101).unwrap());
+        assert_eq!(CommandId::Type, CommandId::try_from(16).unwrap());
     }
 
     #[test]
@@ -267,5 +275,6 @@ mod tests {
         assert_eq!("rename", CommandId::Rename.name());
         assert_eq!("set", CommandId::Set.name());
         assert_eq!("stats", CommandId::Stats.name());
+        assert_eq!("type", CommandId::Type.name());
     }
 }

--- a/engine/src/command/impl/mod.rs
+++ b/engine/src/command/impl/mod.rs
@@ -12,9 +12,10 @@ mod length;
 mod rename;
 mod set;
 mod stats;
+mod r#type;
 
 pub use self::{
     append::Append, decrement::Decrement, decrement_by::DecrementBy, delete::Delete, echo::Echo,
     exists::Exists, increment::Increment, increment_by::IncrementBy, is::Is, keys::Keys,
-    length::Length, rename::Rename, set::Set, stats::Stats,
+    length::Length, r#type::Type, rename::Rename, set::Set, stats::Stats,
 };

--- a/engine/src/command/impl/type.rs
+++ b/engine/src/command/impl/type.rs
@@ -1,0 +1,76 @@
+use crate::{
+    command::{response, Dispatch, DispatchError, DispatchResult, Request},
+    Hop,
+};
+use alloc::vec::Vec;
+
+pub struct Type;
+
+impl Dispatch for Type {
+    fn dispatch(hop: &Hop, req: &Request, resp: &mut Vec<u8>) -> DispatchResult<()> {
+        let key = req.key().ok_or(DispatchError::KeyUnspecified)?;
+
+        if req.key_type().is_some() {
+            return Err(DispatchError::KeyTypeUnexpected);
+        }
+
+        let key = hop
+            .state()
+            .key_ref(key)
+            .ok_or_else(|| DispatchError::KeyNonexistent)?;
+
+        response::write_int(resp, key.kind() as u8 as i64);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Type;
+    use crate::{
+        command::{CommandId, Dispatch, DispatchError, Request, Response},
+        state::{KeyType, Value},
+        Hop,
+    };
+    use alloc::vec::Vec;
+
+    #[test]
+    fn test_key() {
+        let hop = Hop::new();
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        args.push([1].to_vec());
+        let req = Request::new(CommandId::Type, Some(args));
+        let mut resp = Vec::new();
+
+        hop.state().insert(b"foo".to_vec(), Value::Boolean(true));
+
+        assert!(Type::dispatch(&hop, &req, &mut resp).is_ok());
+        assert_eq!(resp, Response::from(KeyType::Boolean as i64).as_bytes());
+    }
+
+    #[test]
+    fn test_no_key() {
+        let hop = Hop::new();
+        let req = Request::new(CommandId::Type, None);
+        let mut resp = Vec::new();
+
+        assert_eq!(
+            DispatchError::KeyUnspecified,
+            Type::dispatch(&hop, &req, &mut resp).unwrap_err()
+        );
+    }
+
+    #[test]
+    fn test_key_type_specified() {
+        let hop = Hop::new();
+        let req = Request::new(CommandId::Type, None);
+        let mut resp = Vec::new();
+
+        assert_eq!(
+            DispatchError::KeyUnspecified,
+            Type::dispatch(&hop, &req, &mut resp).unwrap_err()
+        );
+    }
+}

--- a/engine/src/hop.rs
+++ b/engine/src/hop.rs
@@ -182,6 +182,7 @@ impl Hop {
             CommandId::Rename => Rename::dispatch(self, req, res),
             CommandId::Set => Set::dispatch(self, req, res),
             CommandId::Stats => Stats::dispatch(self, req, res),
+            CommandId::Type => Type::dispatch(self, req, res),
             CommandId::Length => Length::dispatch(self, req, res),
         };
 


### PR DESCRIPTION
Add the `type` command to the engine, which retrieves the type of a key.
The type is in the form of an integer reply, which can be converted to a
key type as key types have stable integer representations.

If a key is not specified, than a `DispatchError::KeyUnspecified` error
is returned.

If a key type is specified, then a `DispatchError::KeyTypeUnexpected`
error is returned.

If a key does not exist, then a `DispatchError::KeyNonexistent` error is
returned.

CLI example:

```
> set foo:int 123
123
> type foo
int
> set foo:str this is a utf-8 valid string
this is a utf-8 valid string
> type foo
str
```

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>