### PR TITLE
engine: add 'get' command

### DIFF
--- a/cli/lib/src/print.rs
+++ b/cli/lib/src/print.rs
@@ -1,4 +1,4 @@
-use hop_engine::state::KeyType;
+use hop_engine::state::{KeyType, Value};
 
 pub fn key_type_name(key_type: KeyType) -> &'static str {
     match key_type {
@@ -10,5 +10,46 @@ pub fn key_type_name(key_type: KeyType) -> &'static str {
         KeyType::Map => "map",
         KeyType::Set => "set",
         KeyType::String => "str",
+    }
+}
+
+pub fn list(items: Vec<Vec<u8>>) -> String {
+    let mut output = String::new();
+
+    for item in items {
+        output.push_str(String::from_utf8_lossy(&item).as_ref());
+        output.push('\n');
+    }
+
+    output.truncate(output.len() - 2);
+
+    output
+}
+
+pub fn map<T: IntoIterator<Item = (Vec<u8>, Vec<u8>)>>(pairs: T) -> String {
+    let mut output = String::new();
+
+    for (k, v) in pairs {
+        output.push_str(String::from_utf8_lossy(&k).as_ref());
+        output.push('=');
+        output.push_str(String::from_utf8_lossy(&v).as_ref());
+        output.push('\n');
+    }
+
+    output.truncate(output.len() - 2);
+
+    output
+}
+
+pub fn value(value: Value) -> String {
+    match value {
+        Value::Boolean(boolean) => boolean.to_string(),
+        Value::Bytes(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
+        Value::Float(float) => float.to_string(),
+        Value::Integer(int) => int.to_string(),
+        Value::List(value_list) => list(value_list),
+        Value::Map(value_map) => map(value_map.into_iter()),
+        Value::Set(set) => list(set.into_iter().collect()),
+        Value::String(string) => string,
     }
 }

--- a/cli/lib/src/process.rs
+++ b/cli/lib/src/process.rs
@@ -241,6 +241,13 @@ where
 
             Ok(exists.to_string().into())
         }
+        CommandId::Get => {
+            let key = req.key().ok_or_else(|| InnerProcessError::KeyUnspecified)?;
+
+            let value = client.get(key).await.map_err(backend_err)?;
+
+            Ok(print::value(value).into())
+        }
         CommandId::Increment => {
             let key = req.key().ok_or_else(|| InnerProcessError::KeyUnspecified)?;
 

--- a/client/src/backend/memory.rs
+++ b/client/src/backend/memory.rs
@@ -150,6 +150,25 @@ impl Backend for MemoryBackend {
         }
     }
 
+    async fn get(&self, key: &[u8]) -> Result<Value, Self::Error> {
+        let req = Request::new(CommandId::Get, Some(vec![key.to_vec()]));
+        let mut resp = Vec::new();
+
+        self.hop.dispatch(&req, &mut resp)?;
+
+        let mut ctx = Context::new();
+
+        let resp = match ctx.feed(&resp).unwrap() {
+            Instruction::Concluded(resp) => resp,
+            Instruction::ReadBytes(_) => unreachable!(),
+        };
+
+        match resp {
+            Response::Value(value) => Ok(value),
+            _ => panic!(),
+        }
+    }
+
     async fn increment(&self, key: &[u8], kind: Option<KeyType>) -> Result<i64, Self::Error> {
         let req = request(CommandId::Increment, Some(vec![key.to_vec()]), kind);
         let mut resp = Vec::new();

--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -27,6 +27,8 @@ pub trait Backend {
         keys: T,
     ) -> Result<bool, Self::Error>;
 
+    async fn get(&self, key: &[u8]) -> Result<Value, Self::Error>;
+
     async fn increment(&self, key: &[u8], key_type: Option<KeyType>) -> Result<i64, Self::Error>;
 
     async fn is<T: IntoIterator<Item = U> + Send, U: AsRef<[u8]> + Send>(

--- a/client/src/backend/server.rs
+++ b/client/src/backend/server.rs
@@ -197,6 +197,15 @@ impl Backend for ServerBackend {
         }
     }
 
+    async fn get(&self, key: &[u8]) -> Result<Value> {
+        let mut args = Vec::new();
+        args.push(key.to_vec());
+
+        let req = Request::new(CommandId::Get, Some(args));
+
+        self.send_and_wait(&req.into_bytes()).await
+    }
+
     async fn increment(&self, key: &[u8], _: Option<KeyType>) -> Result<i64> {
         let mut args = Vec::with_capacity(1);
         args.push(key.to_vec());

--- a/client/src/request/get/get_boolean.rs
+++ b/client/src/request/get/get_boolean.rs
@@ -1,0 +1,54 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `get` command that will resolve to a boolean when `await`ed.
+///
+/// This is returned by [`GetUnconfigured::bool`].
+///
+/// [`GetUnconfigured::bool`]: struct.GetUnconfigured.html#method.bool
+pub struct GetBoolean<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, bool, B::Error>,
+    key: Option<K>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> GetBoolean<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future
+    for GetBoolean<'a, B, K>
+{
+    type Output = Result<bool, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let value = backend.get(key.as_ref()).await?;
+
+                match value {
+                    Value::Boolean(bool) => Ok(bool),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}

--- a/client/src/request/get/get_bytes.rs
+++ b/client/src/request/get/get_bytes.rs
@@ -1,0 +1,52 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `get` command that will resolve to bytes when `await`ed.
+///
+/// This is returned by [`GetUnconfigured::bool`].
+///
+/// [`GetUnconfigured::bool`]: struct.GetUnconfigured.html#method.bool
+pub struct GetBytes<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, Vec<u8>, B::Error>,
+    key: Option<K>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> GetBytes<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for GetBytes<'a, B, K> {
+    type Output = Result<Vec<u8>, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let value = backend.get(key.as_ref()).await?;
+
+                match value {
+                    Value::Bytes(bytes) => Ok(bytes),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}

--- a/client/src/request/get/get_float.rs
+++ b/client/src/request/get/get_float.rs
@@ -1,0 +1,52 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `get` command that will resolve to a float when `await`ed.
+///
+/// This is returned by [`GetUnconfigured::float`].
+///
+/// [`GetUnconfigured::float`]: struct.GetUnconfigured.html#method.float
+pub struct GetFloat<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, f64, B::Error>,
+    key: Option<K>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> GetFloat<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for GetFloat<'a, B, K> {
+    type Output = Result<f64, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let value = backend.get(key.as_ref()).await?;
+
+                match value {
+                    Value::Float(float) => Ok(float),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}

--- a/client/src/request/get/get_integer.rs
+++ b/client/src/request/get/get_integer.rs
@@ -1,0 +1,54 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `get` command that will resolve to an integer when `await`ed.
+///
+/// This is returned by [`GetUnconfigured::int`].
+///
+/// [`GetUnconfigured::int`]: struct.GetUnconfigured.html#method.int
+pub struct GetInteger<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, i64, B::Error>,
+    key: Option<K>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> GetInteger<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future
+    for GetInteger<'a, B, K>
+{
+    type Output = Result<i64, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let value = backend.get(key.as_ref()).await?;
+
+                match value {
+                    Value::Integer(int) => Ok(int),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}

--- a/client/src/request/get/get_list.rs
+++ b/client/src/request/get/get_list.rs
@@ -1,0 +1,52 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `get` command that will resolve to a list when `await`ed.
+///
+/// This is returned by [`GetUnconfigured::list`].
+///
+/// [`GetUnconfigured::list`]: struct.GetUnconfigured.html#method.list
+pub struct GetList<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, Vec<Vec<u8>>, B::Error>,
+    key: Option<K>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> GetList<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for GetList<'a, B, K> {
+    type Output = Result<Vec<Vec<u8>>, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let value = backend.get(key.as_ref()).await?;
+
+                match value {
+                    Value::List(list) => Ok(list),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}

--- a/client/src/request/get/get_map.rs
+++ b/client/src/request/get/get_map.rs
@@ -1,0 +1,53 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use dashmap::DashMap;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `get` command that will resolve to a map when `await`ed.
+///
+/// This is returned by [`GetUnconfigured::map`].
+///
+/// [`GetUnconfigured::map`]: struct.GetUnconfigured.html#method.map
+pub struct GetMap<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, DashMap<Vec<u8>, Vec<u8>>, B::Error>,
+    key: Option<K>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> GetMap<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for GetMap<'a, B, K> {
+    type Output = Result<DashMap<Vec<u8>, Vec<u8>>, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let value = backend.get(key.as_ref()).await?;
+
+                match value {
+                    Value::Map(map) => Ok(map),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}

--- a/client/src/request/get/get_set.rs
+++ b/client/src/request/get/get_set.rs
@@ -1,0 +1,53 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use dashmap::DashSet;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `get` command that will resolve to a set when `await`ed.
+///
+/// This is returned by [`GetUnconfigured::set`].
+///
+/// [`GetUnconfigured::set`]: struct.GetUnconfigured.html#method.set
+pub struct GetSet<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, DashSet<Vec<u8>>, B::Error>,
+    key: Option<K>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> GetSet<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for GetSet<'a, B, K> {
+    type Output = Result<DashSet<Vec<u8>>, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let value = backend.get(key.as_ref()).await?;
+
+                match value {
+                    Value::Set(set) => Ok(set),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}

--- a/client/src/request/get/get_string.rs
+++ b/client/src/request/get/get_string.rs
@@ -1,0 +1,54 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `get` command that will resolve to a string when `await`ed.
+///
+/// This is returned by [`GetUnconfigured::string`].
+///
+/// [`GetUnconfigured::string`]: struct.GetUnconfigured.html#method.string
+pub struct GetString<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, String, B::Error>,
+    key: Option<K>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> GetString<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future
+    for GetString<'a, B, K>
+{
+    type Output = Result<String, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let value = backend.get(key.as_ref()).await?;
+
+                match value {
+                    Value::String(string) => Ok(string),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}

--- a/client/src/request/get/mod.rs
+++ b/client/src/request/get/mod.rs
@@ -1,0 +1,288 @@
+mod get_boolean;
+mod get_bytes;
+mod get_float;
+mod get_integer;
+mod get_list;
+mod get_map;
+mod get_set;
+mod get_string;
+
+pub use self::{
+    get_boolean::GetBoolean, get_bytes::GetBytes, get_float::GetFloat, get_integer::GetInteger,
+    get_list::GetList, get_map::GetMap, get_set::GetSet, get_string::GetString,
+};
+
+use super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A Get request that hasn't been configured with a type of value to get.
+///
+/// This is an intermediary that allows you to cleanly set a value knowing its
+/// type from just the method signature, and get back a value in the same type.
+///
+/// For example, if you call [`GetUnconfigured::bool`], then you will get back a
+/// configured [`GetBoolean`] struct which you can `await`. This struct will
+/// resolve to a boolean on success. If you call [`GetUnconfigured::int`], then
+/// you will get back a [`GetInteger`] which will resolve to an integer when
+/// `await`ed.
+///
+/// If you just want a raw engine value or don't know the type, `await` this
+/// struct to resolve to a value on success.
+///
+/// # Examples
+///
+/// Get the key "foo" which is known to be a boolean:
+///
+/// ```
+/// use hop::Client;
+///
+/// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let client = Client::memory();
+///
+/// client.set("foo").bool(true).await?;
+///
+/// // we know that it will resolve to a boolean on success
+/// assert_eq!(true, client.get("foo").bool().await?);
+/// # Ok(()) }
+/// ```
+///
+/// [`GetUnconfigured::bool`]: #method.bool
+/// [`GetUnconfigured::int`]: #method.int
+/// [`GetBoolean`]: struct.GetBoolean.html
+/// [`GetInteger`]: struct.GetInteger.html
+pub struct GetUnconfigured<'a, B: Backend, K: AsRef<[u8]> + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, Value, B::Error>,
+    key: Option<K>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> GetUnconfigured<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+        }
+    }
+
+    /// An alias for [`bool`].
+    ///
+    /// [`bool`]: #method.bool
+    pub fn boolean(self) -> GetBoolean<'a, B, K> {
+        self.bool()
+    }
+
+    /// Get a key as a boolean.
+    ///
+    /// The returned struct, when `await`ed, will resolve to a boolean on
+    /// success.
+    ///
+    /// # Examples
+    ///
+    /// Get the key "foo" as a boolean:
+    ///
+    /// ```
+    /// use hop::Client;
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::memory();
+    ///
+    /// client.set("foo").bool(true).await?;
+    ///
+    /// client.get("foo").bool().await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn bool(self) -> GetBoolean<'a, B, K> {
+        GetBoolean::new(self.backend.unwrap(), self.key.unwrap())
+    }
+
+    /// Get a key as some bytes.
+    ///
+    /// The returned struct, when `await`ed, will resolve to a `Vec<u8>` on
+    /// success.
+    ///
+    /// # Examples
+    ///
+    /// Get the key "foo" as some bytes:
+    ///
+    /// ```
+    /// use hop::Client;
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::memory();
+    /// client.set("foo").bytes([1u8, 2, 3, 4, 5].as_ref()).await?;
+    ///
+    /// assert_eq!(5, client.get("foo").bytes().await?.len());
+    /// # Ok(()) }
+    /// ```
+    pub fn bytes(self) -> GetBytes<'a, B, K> {
+        GetBytes::new(self.backend.unwrap(), self.key.unwrap())
+    }
+
+    /// Get a key as a float.
+    ///
+    /// The returned struct, when `await`ed, will resolve to a float on success.
+    ///
+    /// # Examples
+    ///
+    /// Get the key "foo" as a float:
+    ///
+    /// ```
+    /// use hop::Client;
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::memory();
+    /// client.set("foo").float(1.23).await?;
+    ///
+    /// assert!(client.get("foo").float().await? > 1.0);
+    /// # Ok(()) }
+    /// ```
+    pub fn float(self) -> GetFloat<'a, B, K> {
+        GetFloat::new(self.backend.unwrap(), self.key.unwrap())
+    }
+
+    /// An alias for [`int`].
+    ///
+    /// [`int`]: #method.int
+    pub fn integer(self) -> GetInteger<'a, B, K> {
+        self.int()
+    }
+
+    /// Get a key as an integer.
+    ///
+    /// The returned struct, when `await`ed, will resolve to an integer on
+    /// success.
+    ///
+    /// # Examples
+    ///
+    /// Get the key "foo" as an integer:
+    ///
+    /// ```
+    /// use hop::Client;
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::memory();
+    /// client.set("foo").int(123).await?;
+    ///
+    /// assert_eq!(123, client.get("foo").int().await?);
+    /// # Ok(()) }
+    /// ```
+    pub fn int(self) -> GetInteger<'a, B, K> {
+        GetInteger::new(self.backend.unwrap(), self.key.unwrap())
+    }
+
+    /// Get a key as an list.
+    ///
+    /// The returned struct, when `await`ed, will resolve to a list on success.
+    ///
+    /// # Examples
+    ///
+    /// Set the key "foo" to the list:
+    ///
+    /// - "foo"
+    /// - "bar"
+    /// - "baz"
+    ///
+    /// Then, retrieve it as a list.
+    ///
+    /// ```
+    /// use hop::Client;
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::memory();
+    /// client.set("foo").list([b"foo".to_vec(), b"bar".to_vec(), b"baz".to_vec()].as_ref()).await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn list(self) -> GetList<'a, B, K> {
+        GetList::new(self.backend.unwrap(), self.key.unwrap())
+    }
+
+    pub fn map(self) -> GetMap<'a, B, K> {
+        GetMap::new(self.backend.unwrap(), self.key.unwrap())
+    }
+
+    /// Get a key to an list.
+    ///
+    /// The returned struct, when `await`ed, will resolve to a list on success.
+    ///
+    /// # Examples
+    ///
+    /// Set the key "foo" to the set:
+    ///
+    /// - "foo"
+    /// - "bar"
+    /// - "foo"
+    ///
+    /// Then, confirm that it has only 2 items, since there are duplicate
+    /// "foo"s.
+    ///
+    /// ```
+    /// use hop::Client;
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::memory();
+    /// client.set("foo").set([b"foo".to_vec(), b"bar".to_vec(), b"foo".to_vec()].to_vec()).await?;
+    ///
+    /// assert_eq!(2, client.get("foo").set().await?.len());
+    /// # Ok(()) }
+    /// ```
+    pub fn set(self) -> GetSet<'a, B, K> {
+        GetSet::new(self.backend.unwrap(), self.key.unwrap())
+    }
+
+    /// An alias for [`str`].
+    ///
+    /// [`str`]: #method.str
+    #[inline]
+    pub fn string(self) -> GetString<'a, B, K> {
+        self.str()
+    }
+
+    /// Get a key as a string.
+    ///
+    /// The returned struct, when `await`ed, will resolve to a string on
+    /// success.
+    ///
+    /// # Examples
+    ///
+    /// Get the key "foo" as a string:
+    ///
+    /// ```
+    /// use hop::Client;
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::memory();
+    /// client.set("foo").str("bar").await?;
+    ///
+    /// assert_eq!("bar", client.get("foo").str().await?);
+    /// # Ok(()) }
+    /// ```
+    pub fn str(self) -> GetString<'a, B, K> {
+        GetString::new(self.backend.unwrap(), self.key.unwrap())
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin + 'a> Future
+    for GetUnconfigured<'a, B, K>
+{
+    type Output = Result<Value, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+
+            self.fut
+                .replace(Box::pin(async move { backend.get(key.as_ref()).await }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}

--- a/client/src/request/mod.rs
+++ b/client/src/request/mod.rs
@@ -1,4 +1,5 @@
 pub mod exists;
+pub mod get;
 pub mod is;
 pub mod set;
 
@@ -21,7 +22,6 @@ pub use self::{
     keys::Keys,
     r#type::Type,
     rename::Rename,
-    set::{SetBytes, SetUnconfigured},
     stats::Stats,
 };
 

--- a/engine/src/command/command_id.rs
+++ b/engine/src/command/command_id.rs
@@ -30,6 +30,7 @@ pub enum CommandId {
     IncrementBy = 2,
     DecrementBy = 3,
     Set = 10,
+    Get = 11,
     Delete = 12,
     Exists = 13,
     Is = 14,
@@ -54,6 +55,7 @@ impl CommandId {
             DecrementBy => One,
             Echo => Multiple,
             Exists => None,
+            Get => None,
             Increment => None,
             IncrementBy => One,
             Is => None,
@@ -77,6 +79,7 @@ impl CommandId {
             DecrementBy => One,
             Echo => None,
             Exists => Multiple,
+            Get => One,
             Increment => One,
             IncrementBy => One,
             Is => Multiple,
@@ -104,6 +107,7 @@ impl CommandId {
             Self::Delete => "delete",
             Self::Echo => "echo",
             Self::Exists => "exists",
+            Self::Get => "get",
             Self::IncrementBy => "increment:by",
             Self::Increment => "increment",
             Self::Is => "is",
@@ -134,6 +138,7 @@ impl FromStr for CommandId {
             "delete" => Self::Delete,
             "echo" => Self::Echo,
             "exists" => Self::Exists,
+            "get" => Self::Get,
             "increment:by" => Self::IncrementBy,
             "increment" => Self::Increment,
             "is" => Self::Is,
@@ -158,6 +163,7 @@ impl TryFrom<u8> for CommandId {
             2 => Self::IncrementBy,
             3 => Self::DecrementBy,
             10 => Self::Set,
+            11 => Self::Get,
             12 => Self::Delete,
             13 => Self::Exists,
             14 => Self::Is,
@@ -223,6 +229,7 @@ mod tests {
         assert_eq!(CommandId::Delete, CommandId::from_str("delete").unwrap());
         assert_eq!(CommandId::Echo, CommandId::from_str("echo").unwrap());
         assert_eq!(CommandId::Exists, CommandId::from_str("exists").unwrap());
+        assert_eq!(CommandId::Get, CommandId::from_str("get").unwrap());
         assert_eq!(
             CommandId::IncrementBy,
             CommandId::from_str("increment:by").unwrap()
@@ -248,6 +255,7 @@ mod tests {
         assert_eq!(CommandId::Delete, CommandId::try_from(12).unwrap());
         assert_eq!(CommandId::Echo, CommandId::try_from(100).unwrap());
         assert_eq!(CommandId::Exists, CommandId::try_from(13).unwrap());
+        assert_eq!(CommandId::Get, CommandId::try_from(11).unwrap());
         assert_eq!(CommandId::IncrementBy, CommandId::try_from(2).unwrap());
         assert_eq!(CommandId::Increment, CommandId::try_from(0).unwrap());
         assert_eq!(CommandId::Is, CommandId::try_from(14).unwrap());
@@ -267,6 +275,7 @@ mod tests {
         assert_eq!("delete", CommandId::Delete.name());
         assert_eq!("echo", CommandId::Echo.name());
         assert_eq!("exists", CommandId::Exists.name());
+        assert_eq!("get", CommandId::Get.name());
         assert_eq!("increment:by", CommandId::IncrementBy.name());
         assert_eq!("increment", CommandId::Increment.name());
         assert_eq!("is", CommandId::Is.name());

--- a/engine/src/command/impl/get.rs
+++ b/engine/src/command/impl/get.rs
@@ -1,0 +1,119 @@
+use crate::{
+    command::{response, Dispatch, DispatchError, DispatchResult, Request},
+    Hop,
+};
+use alloc::vec::Vec;
+
+pub struct Get;
+
+impl Dispatch for Get {
+    fn dispatch(hop: &Hop, req: &Request, resp: &mut Vec<u8>) -> DispatchResult<()> {
+        let key = req.key().ok_or(DispatchError::KeyUnspecified)?;
+        let state = hop.state();
+        let r = state
+            .key_ref(key)
+            .ok_or_else(|| DispatchError::KeyNonexistent)?;
+
+        if let Some(key_type) = req.key_type() {
+            if r.value().kind() != key_type {
+                return Err(DispatchError::KeyTypeDifferent);
+            }
+        }
+
+        response::write_value(resp, r.value());
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Get;
+    use crate::{
+        command::{CommandId, Dispatch, DispatchError, Request, Response},
+        state::{KeyType, Value},
+        Hop,
+    };
+    use alloc::vec::Vec;
+
+    #[test]
+    fn test_bool() {
+        let hop = Hop::new();
+        hop.state().insert(b"foo".to_vec(), Value::Boolean(false));
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        let req = Request::new(CommandId::Get, Some(args));
+        let mut resp = Vec::new();
+
+        assert!(Get::dispatch(&hop, &req, &mut resp).is_ok());
+        assert_eq!(resp, Response::from(false).as_bytes());
+    }
+
+    #[test]
+    fn test_bool_specified_key_type() {
+        let hop = Hop::new();
+        hop.state().insert(b"foo".to_vec(), Value::Boolean(true));
+
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        let req = Request::new_with_type(CommandId::Get, Some(args), KeyType::Boolean);
+        let mut resp = Vec::new();
+
+        assert!(Get::dispatch(&hop, &req, &mut resp).is_ok());
+        assert_eq!(resp, Response::from(true).as_bytes());
+    }
+
+    #[test]
+    fn test_int() {
+        let hop = Hop::new();
+        hop.state().insert(b"foo".to_vec(), Value::Integer(123));
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        let req = Request::new(CommandId::Get, Some(args));
+        let mut resp = Vec::new();
+
+        assert!(Get::dispatch(&hop, &req, &mut resp).is_ok());
+        assert_eq!(resp, Response::from(123).as_bytes());
+    }
+
+    #[test]
+    fn test_no_key() {
+        let hop = Hop::new();
+        let req = Request::new(CommandId::Get, None);
+        let mut resp = Vec::new();
+
+        assert_eq!(
+            DispatchError::KeyUnspecified,
+            Get::dispatch(&hop, &req, &mut resp).unwrap_err()
+        );
+    }
+
+    #[test]
+    fn test_key_nonexistent() {
+        let hop = Hop::new();
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        let req = Request::new(CommandId::Get, Some(args));
+        let mut resp = Vec::new();
+
+        assert_eq!(
+            DispatchError::KeyNonexistent,
+            Get::dispatch(&hop, &req, &mut resp).unwrap_err()
+        );
+    }
+
+    #[test]
+    fn test_key_type_different() {
+        let hop = Hop::new();
+        hop.state().insert(b"foo".to_vec(), Value::Integer(123));
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        let req = Request::new_with_type(CommandId::Get, Some(args), KeyType::Boolean);
+        let mut resp = Vec::new();
+
+        assert_eq!(
+            DispatchError::KeyTypeDifferent,
+            Get::dispatch(&hop, &req, &mut resp).unwrap_err()
+        );
+    }
+}

--- a/engine/src/command/impl/mod.rs
+++ b/engine/src/command/impl/mod.rs
@@ -4,6 +4,7 @@ mod decrement_by;
 mod delete;
 mod echo;
 mod exists;
+mod get;
 mod increment;
 mod increment_by;
 mod is;
@@ -16,6 +17,6 @@ mod r#type;
 
 pub use self::{
     append::Append, decrement::Decrement, decrement_by::DecrementBy, delete::Delete, echo::Echo,
-    exists::Exists, increment::Increment, increment_by::IncrementBy, is::Is, keys::Keys,
+    exists::Exists, get::Get, increment::Increment, increment_by::IncrementBy, is::Is, keys::Keys,
     length::Length, r#type::Type, rename::Rename, set::Set, stats::Stats,
 };

--- a/engine/src/command/response/mod.rs
+++ b/engine/src/command/response/mod.rs
@@ -63,14 +63,7 @@ impl Response {
         match self {
             Self::DispatchError(err) => write_dispatch_error(buf, *err),
             Self::ParseError(err) => write_parse_error(buf, *err),
-            Self::Value(Value::Boolean(boolean)) => write_bool(buf, *boolean),
-            Self::Value(Value::Bytes(bytes)) => write_bytes(buf, bytes),
-            Self::Value(Value::Float(float)) => write_float(buf, *float),
-            Self::Value(Value::Integer(int)) => write_int(buf, *int),
-            Self::Value(Value::List(list)) => write_list(buf, list),
-            Self::Value(Value::Map(map)) => write_map(buf, map),
-            Self::Value(Value::Set(set)) => write_set(buf, set),
-            Self::Value(Value::String(string)) => write_str(buf, string),
+            Self::Value(value) => write_value(buf, value),
         }
     }
 }
@@ -295,6 +288,19 @@ pub fn write_str(to: &mut Vec<u8>, value: &str) {
 
     to.extend_from_slice(&len.to_be_bytes());
     to.extend_from_slice(value.as_bytes());
+}
+
+pub fn write_value(to: &mut Vec<u8>, value: &Value) {
+    match value {
+        Value::Boolean(boolean) => write_bool(to, *boolean),
+        Value::Bytes(bytes) => write_bytes(to, bytes),
+        Value::Float(float) => write_float(to, *float),
+        Value::Integer(int) => write_int(to, *int),
+        Value::List(list) => write_list(to, list),
+        Value::Map(map) => write_map(to, map),
+        Value::Set(set) => write_set(to, set),
+        Value::String(string) => write_str(to, string),
+    }
 }
 
 #[cfg(test)]

--- a/engine/src/hop.rs
+++ b/engine/src/hop.rs
@@ -175,6 +175,7 @@ impl Hop {
             CommandId::Delete => Delete::dispatch(self, req, res),
             CommandId::Echo => Echo::dispatch(self, req, res),
             CommandId::Exists => Exists::dispatch(self, req, res),
+            CommandId::Get => Get::dispatch(self, req, res),
             CommandId::Increment => Increment::dispatch(self, req, res),
             CommandId::IncrementBy => IncrementBy::dispatch(self, req, res),
             CommandId::Is => Is::dispatch(self, req, res),


### PR DESCRIPTION
Add the `get` command, which retrieves the value of a key. A key type
can be specified, which will only get the key if it is of the specified
key type.

Returns a `DispatchError::KeyUnspecified` if the key is not specified.
Returns a `DispatchError::KeyNonexistent` if the key does not exist.
Returns a `DispatchError::KeyTypeDifferent` if the specified key type is
different than the key's type.

CLI example:

```
> set:int foo 123
123
> get foo
123
> get:int foo
123
> set:bool bar true
true
> get:bool bar
true
> get bar
true
```

Closes #7.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>