### PR TITLE
client: make all futures send

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "async-trait 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "dashmap 3.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hop-engine 0.1.0",
+ "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -20,4 +20,5 @@ hop-engine = { default-features = false, path = "../engine" }
 tokio = { default-features = false, features = ["io-util", "net", "sync"], version = "^0.2.20" }
 
 [dev-dependencies]
+static_assertions = { default-features = false, version = "^1.1.0" }
 tokio = { default-features = false, features = ["io-util", "macros", "net", "sync"], version = "^0.2.20" }

--- a/client/src/backend/memory.rs
+++ b/client/src/backend/memory.rs
@@ -337,11 +337,16 @@ impl Backend for MemoryBackend {
 
 #[cfg(test)]
 mod tests {
-    use super::{Backend, MemoryBackend};
+    use super::{Backend, Error, MemoryBackend};
     use hop_engine::state::{
         object::{Boolean, Bytes, Float, Integer, Str},
         KeyType, Value,
     };
+    use static_assertions::assert_impl_all;
+    use std::fmt::Debug;
+
+    assert_impl_all!(Error: Debug, Send, Sync);
+    assert_impl_all!(MemoryBackend: Debug, Default, Send, Sync);
 
     #[tokio::test]
     async fn test_echo() {

--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -13,37 +13,61 @@ use async_trait::async_trait;
 use hop_engine::state::{KeyType, Value};
 
 #[async_trait]
-pub trait Backend {
+pub trait Backend: Send + Sync {
     type Error;
 
-    async fn decrement(&self, key: &[u8], key_type: Option<KeyType>) -> Result<i64, Self::Error>;
+    async fn decrement(&self, key: &[u8], key_type: Option<KeyType>) -> Result<i64, Self::Error>
+    where
+        Self: Sized;
 
-    async fn delete(&self, key: &[u8]) -> Result<Vec<u8>, Self::Error>;
+    async fn delete(&self, key: &[u8]) -> Result<Vec<u8>, Self::Error>
+    where
+        Self: Sized;
 
-    async fn echo(&self, content: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error>;
+    async fn echo(&self, content: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error>
+    where
+        Self: Sized;
 
     async fn exists<T: IntoIterator<Item = U> + Send, U: AsRef<[u8]> + Send>(
         &self,
         keys: T,
-    ) -> Result<bool, Self::Error>;
+    ) -> Result<bool, Self::Error>
+    where
+        Self: Sized;
 
-    async fn get(&self, key: &[u8]) -> Result<Value, Self::Error>;
+    async fn get(&self, key: &[u8]) -> Result<Value, Self::Error>
+    where
+        Self: Sized;
 
-    async fn increment(&self, key: &[u8], key_type: Option<KeyType>) -> Result<i64, Self::Error>;
+    async fn increment(&self, key: &[u8], key_type: Option<KeyType>) -> Result<i64, Self::Error>
+    where
+        Self: Sized;
 
     async fn is<T: IntoIterator<Item = U> + Send, U: AsRef<[u8]> + Send>(
         &self,
         key_type: KeyType,
         keys: T,
-    ) -> Result<bool, Self::Error>;
+    ) -> Result<bool, Self::Error>
+    where
+        Self: Sized;
 
-    async fn key_type(&self, key: &[u8]) -> Result<KeyType, Self::Error>;
+    async fn key_type(&self, key: &[u8]) -> Result<KeyType, Self::Error>
+    where
+        Self: Sized;
 
-    async fn keys(&self, key: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error>;
+    async fn keys(&self, key: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error>
+    where
+        Self: Sized;
 
-    async fn rename(&self, from: &[u8], to: &[u8]) -> Result<Vec<u8>, Self::Error>;
+    async fn rename(&self, from: &[u8], to: &[u8]) -> Result<Vec<u8>, Self::Error>
+    where
+        Self: Sized;
 
-    async fn set<T: Into<Value> + Send>(&self, key: &[u8], value: T) -> Result<Value, Self::Error>;
+    async fn set<T: Into<Value> + Send>(&self, key: &[u8], value: T) -> Result<Value, Self::Error>
+    where
+        Self: Sized;
 
-    async fn stats(&self) -> Result<StatsData, Self::Error>;
+    async fn stats(&self) -> Result<StatsData, Self::Error>
+    where
+        Self: Sized;
 }

--- a/client/src/backend/server.rs
+++ b/client/src/backend/server.rs
@@ -77,6 +77,7 @@ impl StdError for Error {
     }
 }
 
+#[derive(Debug)]
 pub struct ServerBackend {
     reader: Mutex<BufReader<OwnedReadHalf>>,
     writer: Mutex<OwnedWriteHalf>,
@@ -313,4 +314,14 @@ impl Backend for ServerBackend {
 
         self.send_and_wait(&req.into_bytes()).await
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Error, ServerBackend};
+    use static_assertions::assert_impl_all;
+    use std::fmt::Debug;
+
+    assert_impl_all!(Error: Debug, Send, Sync);
+    assert_impl_all!(ServerBackend: Debug, Send, Sync);
 }

--- a/client/src/model.rs
+++ b/client/src/model.rs
@@ -1,6 +1,7 @@
 use hop_engine::metrics::Metric;
 use std::{collections::HashMap, convert::TryInto};
 
+#[derive(Clone, Debug)]
 pub struct StatsData {
     inner: HashMap<Vec<u8>, Vec<u8>>,
 }
@@ -33,4 +34,13 @@ impl StatsData {
     pub fn sessions_started(&self) -> i64 {
         self.int(Metric::SessionsStarted)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StatsData;
+    use static_assertions::assert_impl_all;
+    use std::fmt::Debug;
+
+    assert_impl_all!(StatsData: Clone, Debug);
 }

--- a/client/src/request/delete.rs
+++ b/client/src/request/delete.rs
@@ -7,13 +7,13 @@ use std::{
     task::{Context, Poll},
 };
 
-pub struct Delete<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+pub struct Delete<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
     fut: MaybeInFlightFuture<'a, Vec<u8>, B::Error>,
     key: Option<K>,
 }
 
-impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> Delete<'a, B, K> {
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> Delete<'a, B, K> {
     pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
         Self {
             backend: Some(backend),
@@ -23,7 +23,9 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> Delete<'a, B, K> {
     }
 }
 
-impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for Delete<'a, B, K> {
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
+    for Delete<'a, B, K>
+{
     type Output = Result<Vec<u8>, B::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -31,10 +33,21 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for 
             let backend = { self.backend.take().expect("backend only taken once") };
             let key = self.key.take().expect("key only taken once");
 
-            self.fut
-                .replace(Box::pin(async move { backend.delete(key.as_ref()).await }));
+            self.fut.replace(Box::pin(async move {
+                let key = key.as_ref();
+                backend.delete(key).await
+            }));
         }
 
         self.fut.as_mut().expect("future exists").as_mut().poll(cx)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Delete;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(Delete<MemoryBackend, Vec<u8>>: Send);
 }

--- a/client/src/request/echo.rs
+++ b/client/src/request/echo.rs
@@ -7,13 +7,13 @@ use std::{
     task::{Context, Poll},
 };
 
-pub struct Echo<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+pub struct Echo<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
     content: Option<K>,
     fut: MaybeInFlightFuture<'a, Vec<Vec<u8>>, B::Error>,
 }
 
-impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> Echo<'a, B, K> {
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> Echo<'a, B, K> {
     pub(crate) fn new(backend: Arc<B>, content: K) -> Self {
         Self {
             backend: Some(backend),
@@ -23,7 +23,9 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> Echo<'a, B, K> {
     }
 }
 
-impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for Echo<'a, B, K> {
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
+    for Echo<'a, B, K>
+{
     type Output = Result<Vec<Vec<u8>>, B::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -31,11 +33,21 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for 
             let backend = { self.backend.take().expect("backend only taken once") };
             let content = self.content.take().expect("content only taken once");
 
-            self.fut.replace(Box::pin(
-                async move { backend.echo(content.as_ref()).await },
-            ));
+            self.fut.replace(Box::pin(async move {
+                let content = content.as_ref();
+                backend.echo(content).await
+            }));
         }
 
         self.fut.as_mut().expect("future exists").as_mut().poll(cx)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Echo;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(Echo<MemoryBackend, Vec<u8>>: Send);
 }

--- a/client/src/request/get/get_bytes.rs
+++ b/client/src/request/get/get_bytes.rs
@@ -13,13 +13,13 @@ use std::{
 /// This is returned by [`GetUnconfigured::bool`].
 ///
 /// [`GetUnconfigured::bool`]: struct.GetUnconfigured.html#method.bool
-pub struct GetBytes<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+pub struct GetBytes<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
     fut: MaybeInFlightFuture<'a, Vec<u8>, B::Error>,
     key: Option<K>,
 }
 
-impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> GetBytes<'a, B, K> {
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> GetBytes<'a, B, K> {
     pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
         Self {
             backend: Some(backend),
@@ -29,7 +29,9 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> GetBytes<'a, B, K> {
     }
 }
 
-impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for GetBytes<'a, B, K> {
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
+    for GetBytes<'a, B, K>
+{
     type Output = Result<Vec<u8>, B::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -38,7 +40,8 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for 
             let key = self.key.take().expect("key only taken once");
 
             self.fut.replace(Box::pin(async move {
-                let value = backend.get(key.as_ref()).await?;
+                let key = key.as_ref();
+                let value = backend.get(key).await?;
 
                 match value {
                     Value::Bytes(bytes) => Ok(bytes),
@@ -49,4 +52,13 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for 
 
         self.fut.as_mut().expect("future exists").as_mut().poll(cx)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GetBytes;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(GetBytes<MemoryBackend, Vec<u8>>: Send);
 }

--- a/client/src/request/get/get_list.rs
+++ b/client/src/request/get/get_list.rs
@@ -13,13 +13,13 @@ use std::{
 /// This is returned by [`GetUnconfigured::list`].
 ///
 /// [`GetUnconfigured::list`]: struct.GetUnconfigured.html#method.list
-pub struct GetList<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+pub struct GetList<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
     fut: MaybeInFlightFuture<'a, Vec<Vec<u8>>, B::Error>,
     key: Option<K>,
 }
 
-impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> GetList<'a, B, K> {
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> GetList<'a, B, K> {
     pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
         Self {
             backend: Some(backend),
@@ -29,7 +29,9 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> GetList<'a, B, K> {
     }
 }
 
-impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for GetList<'a, B, K> {
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
+    for GetList<'a, B, K>
+{
     type Output = Result<Vec<Vec<u8>>, B::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -38,7 +40,8 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for 
             let key = self.key.take().expect("key only taken once");
 
             self.fut.replace(Box::pin(async move {
-                let value = backend.get(key.as_ref()).await?;
+                let key = key.as_ref();
+                let value = backend.get(key).await?;
 
                 match value {
                     Value::List(list) => Ok(list),
@@ -49,4 +52,13 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for 
 
         self.fut.as_mut().expect("future exists").as_mut().poll(cx)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GetList;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(GetList<MemoryBackend, Vec<u8>>: Send);
 }

--- a/client/src/request/get/get_map.rs
+++ b/client/src/request/get/get_map.rs
@@ -14,13 +14,13 @@ use std::{
 /// This is returned by [`GetUnconfigured::map`].
 ///
 /// [`GetUnconfigured::map`]: struct.GetUnconfigured.html#method.map
-pub struct GetMap<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+pub struct GetMap<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
     fut: MaybeInFlightFuture<'a, DashMap<Vec<u8>, Vec<u8>>, B::Error>,
     key: Option<K>,
 }
 
-impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> GetMap<'a, B, K> {
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> GetMap<'a, B, K> {
     pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
         Self {
             backend: Some(backend),
@@ -30,7 +30,9 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> GetMap<'a, B, K> {
     }
 }
 
-impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for GetMap<'a, B, K> {
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
+    for GetMap<'a, B, K>
+{
     type Output = Result<DashMap<Vec<u8>, Vec<u8>>, B::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -39,7 +41,8 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for 
             let key = self.key.take().expect("key only taken once");
 
             self.fut.replace(Box::pin(async move {
-                let value = backend.get(key.as_ref()).await?;
+                let key = key.as_ref();
+                let value = backend.get(key).await?;
 
                 match value {
                     Value::Map(map) => Ok(map),
@@ -50,4 +53,13 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for 
 
         self.fut.as_mut().expect("future exists").as_mut().poll(cx)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GetMap;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(GetMap<MemoryBackend, Vec<u8>>: Send);
 }

--- a/client/src/request/get/get_set.rs
+++ b/client/src/request/get/get_set.rs
@@ -14,13 +14,13 @@ use std::{
 /// This is returned by [`GetUnconfigured::set`].
 ///
 /// [`GetUnconfigured::set`]: struct.GetUnconfigured.html#method.set
-pub struct GetSet<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+pub struct GetSet<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
     fut: MaybeInFlightFuture<'a, DashSet<Vec<u8>>, B::Error>,
     key: Option<K>,
 }
 
-impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> GetSet<'a, B, K> {
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> GetSet<'a, B, K> {
     pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
         Self {
             backend: Some(backend),
@@ -30,7 +30,9 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> GetSet<'a, B, K> {
     }
 }
 
-impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for GetSet<'a, B, K> {
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
+    for GetSet<'a, B, K>
+{
     type Output = Result<DashSet<Vec<u8>>, B::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -39,7 +41,8 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for 
             let key = self.key.take().expect("key only taken once");
 
             self.fut.replace(Box::pin(async move {
-                let value = backend.get(key.as_ref()).await?;
+                let key = key.as_ref();
+                let value = backend.get(key).await?;
 
                 match value {
                     Value::Set(set) => Ok(set),
@@ -50,4 +53,13 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for 
 
         self.fut.as_mut().expect("future exists").as_mut().poll(cx)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GetSet;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(GetSet<MemoryBackend, Vec<u8>>: Send);
 }

--- a/client/src/request/get/get_string.rs
+++ b/client/src/request/get/get_string.rs
@@ -13,13 +13,13 @@ use std::{
 /// This is returned by [`GetUnconfigured::string`].
 ///
 /// [`GetUnconfigured::string`]: struct.GetUnconfigured.html#method.string
-pub struct GetString<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+pub struct GetString<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
     fut: MaybeInFlightFuture<'a, String, B::Error>,
     key: Option<K>,
 }
 
-impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> GetString<'a, B, K> {
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> GetString<'a, B, K> {
     pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
         Self {
             backend: Some(backend),
@@ -29,7 +29,7 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> GetString<'a, B, K> {
     }
 }
 
-impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
     for GetString<'a, B, K>
 {
     type Output = Result<String, B::Error>;
@@ -40,7 +40,8 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future
             let key = self.key.take().expect("key only taken once");
 
             self.fut.replace(Box::pin(async move {
-                let value = backend.get(key.as_ref()).await?;
+                let key = key.as_ref();
+                let value = backend.get(key).await?;
 
                 match value {
                     Value::String(string) => Ok(string),
@@ -51,4 +52,13 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future
 
         self.fut.as_mut().expect("future exists").as_mut().poll(cx)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GetString;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(GetString<MemoryBackend, Vec<u8>>: Send);
 }

--- a/client/src/request/increment.rs
+++ b/client/src/request/increment.rs
@@ -8,14 +8,14 @@ use std::{
     task::{Context, Poll},
 };
 
-pub struct Increment<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+pub struct Increment<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
     fut: MaybeInFlightFuture<'a, i64, B::Error>,
     key: Option<K>,
     kind: Option<KeyType>,
 }
 
-impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> Increment<'a, B, K> {
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> Increment<'a, B, K> {
     pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
         Self {
             backend: Some(backend),
@@ -38,7 +38,7 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> Increment<'a, B, K> {
     }
 }
 
-impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
     for Increment<'a, B, K>
 {
     type Output = Result<i64, B::Error>;
@@ -50,10 +50,20 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future
             let kind = self.kind.take();
 
             self.fut.replace(Box::pin(async move {
-                backend.increment(key.as_ref(), kind).await
+                let key = key.as_ref();
+                backend.increment(key, kind).await
             }));
         }
 
         self.fut.as_mut().expect("future exists").as_mut().poll(cx)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Increment;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(Increment<MemoryBackend, Vec<u8>>: Send);
 }

--- a/client/src/request/keys.rs
+++ b/client/src/request/keys.rs
@@ -7,13 +7,13 @@ use std::{
     task::{Context, Poll},
 };
 
-pub struct Keys<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+pub struct Keys<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
     fut: MaybeInFlightFuture<'a, Vec<Vec<u8>>, B::Error>,
     key: Option<K>,
 }
 
-impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> Keys<'a, B, K> {
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> Keys<'a, B, K> {
     pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
         Self {
             backend: Some(backend),
@@ -23,7 +23,9 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> Keys<'a, B, K> {
     }
 }
 
-impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for Keys<'a, B, K> {
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
+    for Keys<'a, B, K>
+{
     type Output = Result<Vec<Vec<u8>>, B::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -31,10 +33,21 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for 
             let backend = { self.backend.take().expect("backend only taken once") };
             let key = self.key.take().expect("key only taken once");
 
-            self.fut
-                .replace(Box::pin(async move { backend.keys(key.as_ref()).await }));
+            self.fut.replace(Box::pin(async move {
+                let key = key.as_ref();
+                backend.keys(key).await
+            }));
         }
 
         self.fut.as_mut().expect("future exists").as_mut().poll(cx)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Keys;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(Keys<MemoryBackend, Vec<u8>>: Send);
 }

--- a/client/src/request/mod.rs
+++ b/client/src/request/mod.rs
@@ -32,7 +32,8 @@ use core::{
 };
 use std::error::Error;
 
-type MaybeInFlightFuture<'a, Ok, Err> = Option<Pin<Box<dyn Future<Output = Result<Ok, Err>> + 'a>>>;
+type MaybeInFlightFuture<'a, Ok, Err> =
+    Option<Pin<Box<dyn Future<Output = Result<Ok, Err>> + Send + 'a>>>;
 
 #[derive(Clone, Debug)]
 pub enum CommandConfigurationError {
@@ -50,3 +51,12 @@ impl Display for CommandConfigurationError {
 }
 
 impl Error for CommandConfigurationError {}
+
+#[cfg(test)]
+mod tests {
+    use super::CommandConfigurationError;
+    use static_assertions::assert_impl_all;
+    use std::fmt::Debug;
+
+    assert_impl_all!(CommandConfigurationError: Clone, Debug, Send);
+}

--- a/client/src/request/set/mod.rs
+++ b/client/src/request/set/mod.rs
@@ -54,12 +54,12 @@ use std::{iter::FromIterator, sync::Arc};
 /// [`SetUnconfigured::int`]: #method.int
 /// [`SetBoolean`]: struct.SetBoolean.html
 /// [`SetInteger`]: struct.SetInteger.html
-pub struct SetUnconfigured<B: Backend, K: AsRef<[u8]> + Unpin> {
+pub struct SetUnconfigured<B: Backend, K: AsRef<[u8]> + Send + Unpin> {
     backend: Arc<B>,
     key: K,
 }
 
-impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetUnconfigured<B, K> {
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> SetUnconfigured<B, K> {
     pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
         Self { backend, key }
     }
@@ -277,4 +277,13 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetUnconfigured<B, K> {
     pub fn value(self, value: impl Into<Value>) -> SetValue<'a, B, K> {
         SetValue::new(self.backend, self.key, value.into())
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SetUnconfigured;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(SetUnconfigured<MemoryBackend, Vec<u8>>: Send);
 }

--- a/client/src/request/set/set_boolean.rs
+++ b/client/src/request/set/set_boolean.rs
@@ -13,14 +13,14 @@ use std::{
 /// This is returned by [`SetUnconfigured::bool`].
 ///
 /// [`SetUnconfigured::bool`]: struct.SetUnconfigured.html#method.bool
-pub struct SetBoolean<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+pub struct SetBoolean<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
     fut: MaybeInFlightFuture<'a, bool, B::Error>,
     key: Option<K>,
     value: Option<bool>,
 }
 
-impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetBoolean<'a, B, K> {
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> SetBoolean<'a, B, K> {
     pub(crate) fn new(backend: Arc<B>, key: K, value: bool) -> Self {
         Self {
             backend: Some(backend),
@@ -31,7 +31,7 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetBoolean<'a, B, K> {
     }
 }
 
-impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
     for SetBoolean<'a, B, K>
 {
     type Output = Result<bool, B::Error>;
@@ -43,7 +43,8 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future
             let bool = self.value.take().expect("value only taken once");
 
             self.fut.replace(Box::pin(async move {
-                let value = backend.set(key.as_ref(), Value::Boolean(bool)).await?;
+                let key = key.as_ref();
+                let value = backend.set(key, Value::Boolean(bool)).await?;
 
                 match value {
                     Value::Boolean(bool) => Ok(bool),
@@ -54,4 +55,13 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future
 
         self.fut.as_mut().expect("future exists").as_mut().poll(cx)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SetBoolean;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(SetBoolean<MemoryBackend, Vec<u8>>: Send);
 }

--- a/client/src/request/set/set_bytes.rs
+++ b/client/src/request/set/set_bytes.rs
@@ -13,14 +13,14 @@ use std::{
 /// This is returned by [`SetUnconfigured::bytes`].
 ///
 /// [`SetUnconfigured::bytes`]: struct.SetUnconfigured.html#method.bytes
-pub struct SetBytes<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+pub struct SetBytes<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
     fut: MaybeInFlightFuture<'a, Vec<u8>, B::Error>,
     key: Option<K>,
     value: Option<Vec<u8>>,
 }
 
-impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetBytes<'a, B, K> {
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> SetBytes<'a, B, K> {
     pub(crate) fn new(backend: Arc<B>, key: K, value: Vec<u8>) -> Self {
         Self {
             backend: Some(backend),
@@ -31,7 +31,9 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetBytes<'a, B, K> {
     }
 }
 
-impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for SetBytes<'a, B, K> {
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
+    for SetBytes<'a, B, K>
+{
     type Output = Result<Vec<u8>, B::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -41,7 +43,8 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for 
             let value = self.value.take().expect("value only taken once");
 
             self.fut.replace(Box::pin(async move {
-                let value = backend.set(key.as_ref(), Value::Bytes(value)).await?;
+                let key = key.as_ref();
+                let value = backend.set(key, Value::Bytes(value)).await?;
 
                 match value {
                     Value::Bytes(bytes) => Ok(bytes),
@@ -52,4 +55,13 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for 
 
         self.fut.as_mut().expect("future exists").as_mut().poll(cx)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SetBytes;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(SetBytes<MemoryBackend, Vec<u8>>: Send);
 }

--- a/client/src/request/set/set_float.rs
+++ b/client/src/request/set/set_float.rs
@@ -13,14 +13,14 @@ use std::{
 /// This is returned by [`SetUnconfigured::float`].
 ///
 /// [`SetUnconfigured::float`]: struct.SetUnconfigured.html#method.float
-pub struct SetFloat<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+pub struct SetFloat<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
     fut: MaybeInFlightFuture<'a, f64, B::Error>,
     key: Option<K>,
     value: Option<f64>,
 }
 
-impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetFloat<'a, B, K> {
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> SetFloat<'a, B, K> {
     pub(crate) fn new(backend: Arc<B>, key: K, value: f64) -> Self {
         Self {
             backend: Some(backend),
@@ -31,7 +31,9 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetFloat<'a, B, K> {
     }
 }
 
-impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for SetFloat<'a, B, K> {
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
+    for SetFloat<'a, B, K>
+{
     type Output = Result<f64, B::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -41,7 +43,8 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for 
             let float = self.value.take().expect("value only taken once");
 
             self.fut.replace(Box::pin(async move {
-                let value = backend.set(key.as_ref(), Value::Float(float)).await?;
+                let key = key.as_ref();
+                let value = backend.set(key, Value::Float(float)).await?;
 
                 match value {
                     Value::Float(float) => Ok(float),
@@ -52,4 +55,13 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for 
 
         self.fut.as_mut().expect("future exists").as_mut().poll(cx)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SetFloat;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(SetFloat<MemoryBackend, Vec<u8>>: Send);
 }

--- a/client/src/request/set/set_integer.rs
+++ b/client/src/request/set/set_integer.rs
@@ -13,14 +13,14 @@ use std::{
 /// This is returned by [`SetUnconfigured::int`].
 ///
 /// [`SetUnconfigured::int`]: struct.SetUnconfigured.html#method.int
-pub struct SetInteger<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+pub struct SetInteger<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
     fut: MaybeInFlightFuture<'a, i64, B::Error>,
     key: Option<K>,
     value: Option<i64>,
 }
 
-impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetInteger<'a, B, K> {
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> SetInteger<'a, B, K> {
     pub(crate) fn new(backend: Arc<B>, key: K, value: i64) -> Self {
         Self {
             backend: Some(backend),
@@ -31,7 +31,7 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetInteger<'a, B, K> {
     }
 }
 
-impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
     for SetInteger<'a, B, K>
 {
     type Output = Result<i64, B::Error>;
@@ -43,7 +43,8 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future
             let int = self.value.take().expect("value only taken once");
 
             self.fut.replace(Box::pin(async move {
-                let value = backend.set(key.as_ref(), Value::Integer(int)).await?;
+                let key = key.as_ref();
+                let value = backend.set(key, Value::Integer(int)).await?;
 
                 match value {
                     Value::Integer(int) => Ok(int),
@@ -54,4 +55,13 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future
 
         self.fut.as_mut().expect("future exists").as_mut().poll(cx)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SetInteger;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(SetInteger<MemoryBackend, Vec<u8>>: Send);
 }

--- a/client/src/request/set/set_list.rs
+++ b/client/src/request/set/set_list.rs
@@ -13,14 +13,14 @@ use std::{
 /// This is returned by [`SetUnconfigured::list`].
 ///
 /// [`SetUnconfigured::list`]: struct.SetUnconfigured.html#method.list
-pub struct SetList<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+pub struct SetList<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
     fut: MaybeInFlightFuture<'a, Vec<Vec<u8>>, B::Error>,
     key: Option<K>,
     value: Option<Vec<Vec<u8>>>,
 }
 
-impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetList<'a, B, K> {
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> SetList<'a, B, K> {
     pub(crate) fn new(backend: Arc<B>, key: K, value: Vec<Vec<u8>>) -> Self {
         Self {
             backend: Some(backend),
@@ -31,7 +31,9 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetList<'a, B, K> {
     }
 }
 
-impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for SetList<'a, B, K> {
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
+    for SetList<'a, B, K>
+{
     type Output = Result<Vec<Vec<u8>>, B::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -41,7 +43,8 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for 
             let value = self.value.take().expect("value only taken once");
 
             self.fut.replace(Box::pin(async move {
-                let value = backend.set(key.as_ref(), Value::List(value)).await?;
+                let key = key.as_ref();
+                let value = backend.set(key, Value::List(value)).await?;
 
                 match value {
                     Value::List(list) => Ok(list),
@@ -52,4 +55,13 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for 
 
         self.fut.as_mut().expect("future exists").as_mut().poll(cx)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SetList;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(SetList<MemoryBackend, Vec<u8>>: Send);
 }

--- a/client/src/request/set/set_set.rs
+++ b/client/src/request/set/set_set.rs
@@ -14,14 +14,14 @@ use std::{
 /// This is returned by [`SetUnconfigured::set`].
 ///
 /// [`SetUnconfigured::set`]: struct.SetUnconfigured.html#method.set
-pub struct SetSet<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+pub struct SetSet<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
     fut: MaybeInFlightFuture<'a, Vec<Vec<u8>>, B::Error>,
     key: Option<K>,
     value: Option<Vec<Vec<u8>>>,
 }
 
-impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetSet<'a, B, K> {
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> SetSet<'a, B, K> {
     pub(crate) fn new(backend: Arc<B>, key: K, value: Vec<Vec<u8>>) -> Self {
         Self {
             backend: Some(backend),
@@ -32,7 +32,9 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetSet<'a, B, K> {
     }
 }
 
-impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for SetSet<'a, B, K> {
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
+    for SetSet<'a, B, K>
+{
     type Output = Result<Vec<Vec<u8>>, B::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -42,8 +44,9 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for 
             let value = self.value.take().expect("value only taken once");
 
             self.fut.replace(Box::pin(async move {
+                let key = key.as_ref();
                 let value = backend
-                    .set(key.as_ref(), Value::Set(FromIterator::from_iter(value)))
+                    .set(key, Value::Set(FromIterator::from_iter(value)))
                     .await?;
 
                 match value {
@@ -55,4 +58,13 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for 
 
         self.fut.as_mut().expect("future exists").as_mut().poll(cx)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SetSet;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(SetSet<MemoryBackend, Vec<u8>>: Send);
 }

--- a/client/src/request/set/set_string.rs
+++ b/client/src/request/set/set_string.rs
@@ -13,14 +13,14 @@ use std::{
 /// This is returned by [`SetUnconfigured::string`].
 ///
 /// [`SetUnconfigured::string`]: struct.SetUnconfigured.html#method.string
-pub struct SetString<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+pub struct SetString<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
     fut: MaybeInFlightFuture<'a, String, B::Error>,
     key: Option<K>,
     value: Option<String>,
 }
 
-impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetString<'a, B, K> {
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> SetString<'a, B, K> {
     pub(crate) fn new(backend: Arc<B>, key: K, value: String) -> Self {
         Self {
             backend: Some(backend),
@@ -31,7 +31,7 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetString<'a, B, K> {
     }
 }
 
-impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
     for SetString<'a, B, K>
 {
     type Output = Result<String, B::Error>;
@@ -43,7 +43,8 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future
             let value = self.value.take().expect("value only taken once");
 
             self.fut.replace(Box::pin(async move {
-                let value = backend.set(key.as_ref(), Value::String(value)).await?;
+                let key = key.as_ref();
+                let value = backend.set(key, Value::String(value)).await?;
 
                 match value {
                     Value::String(string) => Ok(string),
@@ -54,4 +55,13 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future
 
         self.fut.as_mut().expect("future exists").as_mut().poll(cx)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SetString;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(SetString<MemoryBackend, Vec<u8>>: Send);
 }

--- a/client/src/request/set/set_value.rs
+++ b/client/src/request/set/set_value.rs
@@ -14,14 +14,14 @@ use std::{
 /// This is returned by [`SetUnconfigured::value`].
 ///
 /// [`SetUnconfigured::value`]: struct.SetUnconfigured.html#method.value
-pub struct SetValue<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+pub struct SetValue<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
     fut: MaybeInFlightFuture<'a, Value, B::Error>,
     key: Option<K>,
     value: Option<Value>,
 }
 
-impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetValue<'a, B, K> {
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> SetValue<'a, B, K> {
     pub(crate) fn new(backend: Arc<B>, key: K, value: Value) -> Self {
         Self {
             backend: Some(backend),
@@ -32,7 +32,9 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> SetValue<'a, B, K> {
     }
 }
 
-impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for SetValue<'a, B, K> {
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
+    for SetValue<'a, B, K>
+{
     type Output = Result<Value, B::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -41,11 +43,21 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for 
             let key = self.key.take().expect("key only taken once");
             let value = self.value.take().expect("value only taken once");
 
-            self.fut.replace(Box::pin(
-                async move { backend.set(key.as_ref(), value).await },
-            ));
+            self.fut.replace(Box::pin(async move {
+                let key = key.as_ref();
+                backend.set(key, value).await
+            }));
         }
 
         self.fut.as_mut().expect("future exists").as_mut().poll(cx)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SetValue;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(SetValue<MemoryBackend, Vec<u8>>: Send);
 }

--- a/client/src/request/stats.rs
+++ b/client/src/request/stats.rs
@@ -21,7 +21,7 @@ impl<'a, B: Backend> Stats<'a, B> {
     }
 }
 
-impl<'a, B: Backend + Send + Sync + 'static> Future for Stats<'a, B> {
+impl<'a, B: Backend + Send + 'static> Future for Stats<'a, B> {
     type Output = Result<StatsData, B::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -34,4 +34,13 @@ impl<'a, B: Backend + Send + Sync + 'static> Future for Stats<'a, B> {
 
         self.fut.as_mut().expect("future exists").as_mut().poll(cx)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Stats;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(Stats<MemoryBackend>: Send);
 }

--- a/client/src/request/type.rs
+++ b/client/src/request/type.rs
@@ -8,13 +8,13 @@ use std::{
     task::{Context, Poll},
 };
 
-pub struct Type<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> {
+pub struct Type<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
     fut: MaybeInFlightFuture<'a, KeyType, B::Error>,
     key: Option<K>,
 }
 
-impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> Type<'a, B, K> {
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> Type<'a, B, K> {
     pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
         Self {
             backend: Some(backend),
@@ -24,7 +24,9 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Unpin> Type<'a, B, K> {
     }
 }
 
-impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for Type<'a, B, K> {
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
+    for Type<'a, B, K>
+{
     type Output = Result<KeyType, B::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -32,11 +34,21 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Unpin> Future for 
             let backend = { self.backend.take().expect("backend only taken once") };
             let key = self.key.take().expect("key only taken once");
 
-            self.fut.replace(Box::pin(
-                async move { backend.key_type(key.as_ref()).await },
-            ));
+            self.fut.replace(Box::pin(async move {
+                let key = key.as_ref();
+                backend.key_type(key).await
+            }));
         }
 
         self.fut.as_mut().expect("future exists").as_mut().poll(cx)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Type;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(Type<MemoryBackend, Vec<u8>>: Send);
 }


### PR DESCRIPTION
Make all of the futures send, and sprinkle around static assertions to
ensure some of the trait bounds of structs.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>