### PR TITLE
engine: implement decrement by, increment by

### DIFF
--- a/engine/src/command/impl/decrement.rs
+++ b/engine/src/command/impl/decrement.rs
@@ -11,6 +11,45 @@ impl Dispatch for Decrement {
     fn dispatch(hop: &Hop, req: &Request, resp: &mut Vec<u8>) -> DispatchResult<()> {
         let key = req.key().ok_or(DispatchError::KeyUnspecified)?;
 
-        DecrementBy::decrement(hop, key, req.key_type(), 1, resp)
+        DecrementBy::decrement(hop, key, resp)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Decrement;
+    use crate::{
+        command::{CommandId, Dispatch, DispatchError, Request, Response},
+        state::object::Integer,
+        Hop,
+    };
+    use alloc::vec::Vec;
+
+    #[test]
+    fn test_decrement() {
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        let req = Request::new(CommandId::Decrement, Some(args));
+        let hop = Hop::new();
+        let mut resp = Vec::new();
+
+        assert!(Decrement::dispatch(&hop, &req, &mut resp).is_ok());
+        assert_eq!(Response::from(-1i64).as_bytes(), resp);
+        assert_eq!(
+            Some(-1),
+            hop.state().typed_key::<Integer>(b"foo").as_deref().copied()
+        );
+    }
+
+    #[test]
+    fn test_no_key() {
+        let req = Request::new(CommandId::Decrement, None);
+        let hop = Hop::new();
+        let mut resp = Vec::new();
+
+        assert_eq!(
+            DispatchError::KeyUnspecified,
+            Decrement::dispatch(&hop, &req, &mut resp).unwrap_err()
+        );
     }
 }

--- a/engine/src/command/impl/decrement_by.rs
+++ b/engine/src/command/impl/decrement_by.rs
@@ -2,7 +2,7 @@ use super::super::{response, Dispatch, DispatchError, DispatchResult, Request};
 use crate::{
     state::{
         object::{Float, Integer},
-        KeyType,
+        KeyType, Value,
     },
     Hop,
 };
@@ -11,38 +11,50 @@ use alloc::vec::Vec;
 pub struct DecrementBy;
 
 impl DecrementBy {
-    pub fn decrement(
+    pub fn decrement_float_by(
         hop: &Hop,
         key: &[u8],
-        key_type: Option<KeyType>,
+        amount: f64,
+        resp: &mut Vec<u8>,
+    ) -> DispatchResult<()> {
+        let mut float = hop
+            .state()
+            .typed_key::<Float>(key)
+            .ok_or(DispatchError::KeyUnspecified)?;
+
+        *float -= amount as f64;
+
+        response::write_float(resp, *float);
+
+        Ok(())
+    }
+
+    pub fn decrement_int_by(
+        hop: &Hop,
+        key: &[u8],
         amount: i64,
         resp: &mut Vec<u8>,
     ) -> DispatchResult<()> {
-        match key_type {
-            Some(KeyType::Integer) | None => {
-                let mut int = hop
-                    .state()
-                    .typed_key::<Integer>(key)
-                    .ok_or(DispatchError::KeyUnspecified)?;
+        let mut int = hop
+            .state()
+            .typed_key::<Integer>(key)
+            .ok_or(DispatchError::KeyUnspecified)?;
 
-                *int -= amount;
+        *int -= amount;
 
-                response::write_int(resp, *int);
-            }
-            Some(KeyType::Float) => {
-                let mut float = hop
-                    .state()
-                    .typed_key::<Float>(key)
-                    .ok_or(DispatchError::KeyUnspecified)?;
-
-                *float -= amount as f64;
-
-                response::write_float(resp, *float);
-            }
-            Some(_) => return Err(DispatchError::KeyTypeInvalid),
-        }
+        response::write_int(resp, *int);
 
         Ok(())
+    }
+
+    pub fn decrement(hop: &Hop, key: &[u8], resp: &mut Vec<u8>) -> DispatchResult<()> {
+        hop.state().key_or_insert_with(b"foo", Value::integer);
+
+        match hop.state().key_ref(key).map(|r| r.value().kind()) {
+            Some(KeyType::Float) => Self::decrement_float_by(hop, key, 1f64, resp),
+            Some(KeyType::Integer) => Self::decrement_int_by(hop, key, 1, resp),
+            _ => Err(DispatchError::KeyTypeDifferent),
+        }
     }
 }
 
@@ -50,6 +62,67 @@ impl Dispatch for DecrementBy {
     fn dispatch(hop: &Hop, req: &Request, resp: &mut Vec<u8>) -> DispatchResult<()> {
         let key = req.key().ok_or(DispatchError::KeyUnspecified)?;
 
-        Self::decrement(hop, key, req.key_type(), 1, resp)
+        if let Some(int) = req.typed_arg::<i64>(1) {
+            Self::decrement_int_by(hop, key, int, resp)
+        } else if let Some(float) = req.typed_arg::<f64>(1) {
+            Self::decrement_float_by(hop, key, float, resp)
+        } else {
+            Err(DispatchError::ArgumentRetrieval)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DecrementBy;
+    use crate::{
+        command::{request, CommandId, Dispatch, DispatchError, Request, Response},
+        state::{object::Integer, Value},
+        Hop,
+    };
+    use alloc::vec::Vec;
+
+    #[test]
+    fn test_decrement_by() {
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        request::write_value_to_args(Value::Integer(3), &mut args);
+        let req = Request::new(CommandId::DecrementBy, Some(args));
+        let hop = Hop::new();
+        let mut resp = Vec::new();
+
+        assert!(DecrementBy::dispatch(&hop, &req, &mut resp).is_ok());
+        assert_eq!(Response::from(-3i64).as_bytes(), resp);
+        assert_eq!(
+            Some(-3),
+            hop.state().typed_key::<Integer>(b"foo").as_deref().copied()
+        );
+    }
+
+    #[test]
+    fn test_no_key() {
+        let req = Request::new(CommandId::Decrement, None);
+        let hop = Hop::new();
+        let mut resp = Vec::new();
+
+        assert_eq!(
+            DispatchError::KeyUnspecified,
+            DecrementBy::dispatch(&hop, &req, &mut resp).unwrap_err()
+        );
+    }
+
+    #[test]
+    fn test_no_amount() {
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+
+        let req = Request::new(CommandId::DecrementBy, Some(args));
+        let hop = Hop::new();
+        let mut resp = Vec::new();
+
+        assert_eq!(
+            DispatchError::ArgumentRetrieval,
+            DecrementBy::dispatch(&hop, &req, &mut resp).unwrap_err()
+        );
     }
 }

--- a/engine/src/command/impl/increment.rs
+++ b/engine/src/command/impl/increment.rs
@@ -11,6 +11,45 @@ impl Dispatch for Increment {
     fn dispatch(hop: &Hop, req: &Request, resp: &mut Vec<u8>) -> DispatchResult<()> {
         let key = req.key().ok_or(DispatchError::KeyUnspecified)?;
 
-        IncrementBy::increment(hop, key, req.key_type(), 1, resp)
+        IncrementBy::increment(hop, key, resp)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Increment;
+    use crate::{
+        command::{CommandId, Dispatch, DispatchError, Request, Response},
+        state::object::Integer,
+        Hop,
+    };
+    use alloc::vec::Vec;
+
+    #[test]
+    fn test_increment() {
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        let req = Request::new(CommandId::Increment, Some(args));
+        let hop = Hop::new();
+        let mut resp = Vec::new();
+
+        assert!(Increment::dispatch(&hop, &req, &mut resp).is_ok());
+        assert_eq!(Response::from(1i64).as_bytes(), resp);
+        assert_eq!(
+            Some(1),
+            hop.state().typed_key::<Integer>(b"foo").as_deref().copied()
+        );
+    }
+
+    #[test]
+    fn test_no_key() {
+        let req = Request::new(CommandId::Increment, None);
+        let hop = Hop::new();
+        let mut resp = Vec::new();
+
+        assert_eq!(
+            DispatchError::KeyUnspecified,
+            Increment::dispatch(&hop, &req, &mut resp).unwrap_err()
+        );
     }
 }

--- a/engine/src/command/impl/increment_by.rs
+++ b/engine/src/command/impl/increment_by.rs
@@ -2,7 +2,7 @@ use super::super::{response, Dispatch, DispatchError, DispatchResult, Request};
 use crate::{
     state::{
         object::{Float, Integer},
-        KeyType,
+        KeyType, Value,
     },
     Hop,
 };
@@ -11,38 +11,50 @@ use alloc::vec::Vec;
 pub struct IncrementBy;
 
 impl IncrementBy {
-    pub fn increment(
+    pub fn increment_float_by(
         hop: &Hop,
         key: &[u8],
-        key_type: Option<KeyType>,
+        amount: f64,
+        resp: &mut Vec<u8>,
+    ) -> DispatchResult<()> {
+        let mut float = hop
+            .state()
+            .typed_key::<Float>(key)
+            .ok_or(DispatchError::KeyUnspecified)?;
+
+        *float += amount;
+
+        response::write_float(resp, *float);
+
+        Ok(())
+    }
+
+    pub fn increment_int_by(
+        hop: &Hop,
+        key: &[u8],
         amount: i64,
         resp: &mut Vec<u8>,
     ) -> DispatchResult<()> {
-        match key_type {
-            Some(KeyType::Integer) | None => {
-                let mut int = hop
-                    .state()
-                    .typed_key::<Integer>(key)
-                    .ok_or(DispatchError::KeyUnspecified)?;
+        let mut int = hop
+            .state()
+            .typed_key::<Integer>(key)
+            .ok_or(DispatchError::KeyUnspecified)?;
 
-                *int += amount;
+        *int += amount;
 
-                response::write_int(resp, *int)
-            }
-            Some(KeyType::Float) => {
-                let mut float = hop
-                    .state()
-                    .typed_key::<Float>(key)
-                    .ok_or(DispatchError::KeyUnspecified)?;
-
-                *float += amount as f64;
-
-                response::write_float(resp, *float)
-            }
-            Some(_) => return Err(DispatchError::KeyTypeInvalid),
-        }
+        response::write_int(resp, *int);
 
         Ok(())
+    }
+
+    pub fn increment(hop: &Hop, key: &[u8], resp: &mut Vec<u8>) -> DispatchResult<()> {
+        hop.state().key_or_insert_with(b"foo", Value::integer);
+
+        match hop.state().key_ref(key).map(|r| r.value().kind()) {
+            Some(KeyType::Float) => Self::increment_float_by(hop, key, 1f64, resp),
+            Some(KeyType::Integer) => Self::increment_int_by(hop, key, 1, resp),
+            _ => Err(DispatchError::KeyTypeDifferent),
+        }
     }
 }
 
@@ -50,6 +62,67 @@ impl Dispatch for IncrementBy {
     fn dispatch(hop: &Hop, req: &Request, resp: &mut Vec<u8>) -> DispatchResult<()> {
         let key = req.key().ok_or(DispatchError::KeyUnspecified)?;
 
-        Self::increment(hop, key, req.key_type(), 1, resp)
+        if let Some(int) = req.typed_arg::<i64>(1) {
+            Self::increment_int_by(hop, key, int, resp)
+        } else if let Some(float) = req.typed_arg::<f64>(1) {
+            Self::increment_float_by(hop, key, float, resp)
+        } else {
+            Err(DispatchError::ArgumentRetrieval)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IncrementBy;
+    use crate::{
+        command::{request, CommandId, Dispatch, DispatchError, Request, Response},
+        state::{object::Integer, Value},
+        Hop,
+    };
+    use alloc::vec::Vec;
+
+    #[test]
+    fn test_decrement_by() {
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+        request::write_value_to_args(Value::Integer(3), &mut args);
+        let req = Request::new(CommandId::IncrementBy, Some(args));
+        let hop = Hop::new();
+        let mut resp = Vec::new();
+
+        assert!(IncrementBy::dispatch(&hop, &req, &mut resp).is_ok());
+        assert_eq!(Response::from(3i64).as_bytes(), resp);
+        assert_eq!(
+            Some(3),
+            hop.state().typed_key::<Integer>(b"foo").as_deref().copied()
+        );
+    }
+
+    #[test]
+    fn test_no_key() {
+        let req = Request::new(CommandId::Decrement, None);
+        let hop = Hop::new();
+        let mut resp = Vec::new();
+
+        assert_eq!(
+            DispatchError::KeyUnspecified,
+            IncrementBy::dispatch(&hop, &req, &mut resp).unwrap_err()
+        );
+    }
+
+    #[test]
+    fn test_no_amount() {
+        let mut args = Vec::new();
+        args.push(b"foo".to_vec());
+
+        let req = Request::new(CommandId::IncrementBy, Some(args));
+        let hop = Hop::new();
+        let mut resp = Vec::new();
+
+        assert_eq!(
+            DispatchError::ArgumentRetrieval,
+            IncrementBy::dispatch(&hop, &req, &mut resp).unwrap_err()
+        );
     }
 }


### PR DESCRIPTION
Implement the `decrement:by` and `increment:by` commands, which
previously worked the same as their `decrement` and `increment`
equivalents.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>