### PR TITLE
client: implement missing commands

### DIFF
--- a/cli/lib/src/process.rs
+++ b/cli/lib/src/process.rs
@@ -162,6 +162,7 @@ where
         Ok(memory_error) => {
             return match *memory_error {
                 MemoryError::KeyTypeInvalid { .. } => InnerProcessError::KeyTypeInvalid,
+                MemoryError::KeyTypeUnsupported { .. } => InnerProcessError::KeyTypeInvalid,
                 MemoryError::RunningCommand { source } => match source {
                     DispatchError::ArgumentRetrieval => InnerProcessError::TooFewArguments,
                     DispatchError::KeyNonexistent => InnerProcessError::KeyNonexistent,
@@ -197,7 +198,7 @@ where
 
             let v = client.decrement(key).await.map_err(backend_err)?;
 
-            Ok(v.to_string().into())
+            Ok(print::value(v).into())
         }
         CommandId::Delete => {
             let key = req.key().ok_or_else(|| InnerProcessError::KeyUnspecified)?;
@@ -253,7 +254,7 @@ where
 
             let v = client.increment(key).await.map_err(backend_err)?;
 
-            Ok(v.to_string().into())
+            Ok(print::value(v).into())
         }
         CommandId::Is => {
             let key_type = req

--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -10,13 +10,32 @@ pub use self::server::ServerBackend;
 
 use crate::model::StatsData;
 use async_trait::async_trait;
-use hop_engine::state::{KeyType, Value};
+use hop_engine::{
+    command::{CommandId, Request},
+    state::{KeyType, Value},
+};
 
 #[async_trait]
 pub trait Backend: Send + Sync {
     type Error;
 
-    async fn decrement(&self, key: &[u8], key_type: Option<KeyType>) -> Result<i64, Self::Error>
+    async fn append<T: Into<Value> + Send>(
+        &self,
+        key: &[u8],
+        value: T,
+    ) -> Result<Value, Self::Error>
+    where
+        Self: Sized;
+
+    async fn decrement_by<T: Into<Value> + Send>(
+        &self,
+        key: &[u8],
+        value: T,
+    ) -> Result<Value, Self::Error>
+    where
+        Self: Sized;
+
+    async fn decrement(&self, key: &[u8], key_type: Option<KeyType>) -> Result<Value, Self::Error>
     where
         Self: Sized;
 
@@ -39,7 +58,15 @@ pub trait Backend: Send + Sync {
     where
         Self: Sized;
 
-    async fn increment(&self, key: &[u8], key_type: Option<KeyType>) -> Result<i64, Self::Error>
+    async fn increment_by<T: Into<Value> + Send>(
+        &self,
+        key: &[u8],
+        value: T,
+    ) -> Result<Value, Self::Error>
+    where
+        Self: Sized;
+
+    async fn increment(&self, key: &[u8], key_type: Option<KeyType>) -> Result<Value, Self::Error>
     where
         Self: Sized;
 
@@ -59,6 +86,10 @@ pub trait Backend: Send + Sync {
     where
         Self: Sized;
 
+    async fn length(&self, key: &[u8], key_type: Option<KeyType>) -> Result<i64, Self::Error>
+    where
+        Self: Sized;
+
     async fn rename(&self, from: &[u8], to: &[u8]) -> Result<Vec<u8>, Self::Error>
     where
         Self: Sized;
@@ -70,4 +101,16 @@ pub trait Backend: Send + Sync {
     async fn stats(&self) -> Result<StatsData, Self::Error>
     where
         Self: Sized;
+}
+
+fn make_request(
+    cmd_id: CommandId,
+    args: Option<Vec<Vec<u8>>>,
+    key_type: Option<KeyType>,
+) -> Request {
+    if let Some(key_type) = key_type {
+        Request::new_with_type(cmd_id, args, key_type)
+    } else {
+        Request::new(cmd_id, args)
+    }
 }

--- a/client/src/backend/server.rs
+++ b/client/src/backend/server.rs
@@ -35,6 +35,7 @@ pub enum Error {
     ConnectionClosed,
     Dispatching { reason: DispatchError },
     KeyTypeInvalid { number: u8 },
+    KeyTypeUnsupported { key_type: KeyType },
     ReadingMessage { source: IoError },
     WritingMessage { source: IoError },
 }
@@ -56,6 +57,10 @@ impl Display for Error {
                 "the provided key type ({}) is invalid",
                 number
             )),
+            Self::KeyTypeUnsupported { key_type } => f.write_fmt(format_args!(
+                "key type {} is not supported by this command",
+                *key_type as u8
+            )),
             Self::ReadingMessage { .. } => f.write_str("failed to read a message"),
             Self::WritingMessage { .. } => f.write_str("failed to write a message"),
         }
@@ -71,6 +76,7 @@ impl StdError for Error {
             Self::ConnectionClosed => None,
             Self::Dispatching { .. } => None,
             Self::KeyTypeInvalid { .. } => None,
+            Self::KeyTypeUnsupported { .. } => None,
             Self::ReadingMessage { source } => Some(source),
             Self::WritingMessage { source } => Some(source),
         }
@@ -140,15 +146,62 @@ impl ServerBackend {
 impl Backend for ServerBackend {
     type Error = Error;
 
-    async fn decrement(&self, key: &[u8], _: Option<KeyType>) -> Result<i64> {
-        let mut args = Vec::with_capacity(1);
+    async fn append<T: Into<Value> + Send>(&self, key: &[u8], value: T) -> Result<Value> {
+        let mut args = Vec::new();
         args.push(key.to_vec());
-        let req = Request::new(CommandId::Decrement, Some(args));
+        let value = value.into();
+        let key_type = value.kind();
+
+        match value {
+            Value::Bytes(bytes) => args.push(bytes),
+            Value::List(list) => {
+                for item in list {
+                    args.push(item);
+                }
+            }
+            Value::String(string) => args.push(string.into_bytes()),
+            _ => return Err(Error::KeyTypeUnsupported { key_type }),
+        }
+
+        let req = Request::new_with_type(CommandId::Append, Some(args), key_type);
+
+        self.send_and_wait(&req.into_bytes()).await
+    }
+
+    async fn decrement_by<T: Into<Value> + Send>(&self, key: &[u8], value: T) -> Result<Value> {
+        let value = value.into();
+        let key_type = value.kind();
+
+        let mut args = Vec::new();
+        args.push(key.to_vec());
+
+        if key_type != KeyType::Float && key_type != KeyType::Integer {
+            return Err(Error::KeyTypeUnsupported { key_type });
+        }
+
+        request::write_value_to_args(value, &mut args);
+
+        let req = Request::new_with_type(CommandId::DecrementBy, Some(args), key_type);
 
         let value = self.send_and_wait(&req.into_bytes()).await?;
 
         match value {
-            Value::Integer(int) => Ok(int),
+            Value::Float(float) => Ok(Value::Float(float)),
+            Value::Integer(int) => Ok(Value::Integer(int)),
+            _ => Err(Error::BadResponse),
+        }
+    }
+
+    async fn decrement(&self, key: &[u8], key_type: Option<KeyType>) -> Result<Value> {
+        let mut args = Vec::with_capacity(1);
+        args.push(key.to_vec());
+        let req = super::make_request(CommandId::Decrement, Some(args), key_type);
+
+        let value = self.send_and_wait(&req.into_bytes()).await?;
+
+        match value {
+            Value::Float(float) => Ok(Value::Float(float)),
+            Value::Integer(int) => Ok(Value::Integer(int)),
             _ => Err(Error::BadResponse),
         }
     }
@@ -207,7 +260,31 @@ impl Backend for ServerBackend {
         self.send_and_wait(&req.into_bytes()).await
     }
 
-    async fn increment(&self, key: &[u8], _: Option<KeyType>) -> Result<i64> {
+    async fn increment_by<T: Into<Value> + Send>(&self, key: &[u8], value: T) -> Result<Value> {
+        let value = value.into();
+        let key_type = value.kind();
+
+        let mut args = Vec::new();
+        args.push(key.to_vec());
+
+        if key_type != KeyType::Float && key_type != KeyType::Integer {
+            return Err(Error::KeyTypeUnsupported { key_type });
+        }
+
+        request::write_value_to_args(value, &mut args);
+
+        let req = Request::new_with_type(CommandId::IncrementBy, Some(args), key_type);
+
+        let value = self.send_and_wait(&req.into_bytes()).await?;
+
+        match value {
+            Value::Float(float) => Ok(Value::Float(float)),
+            Value::Integer(int) => Ok(Value::Integer(int)),
+            _ => Err(Error::BadResponse),
+        }
+    }
+
+    async fn increment(&self, key: &[u8], _: Option<KeyType>) -> Result<Value> {
         let mut args = Vec::with_capacity(1);
         args.push(key.to_vec());
         let req = Request::new(CommandId::Increment, Some(args));
@@ -215,7 +292,8 @@ impl Backend for ServerBackend {
         let value = self.send_and_wait(&req.into_bytes()).await?;
 
         match value {
-            Value::Integer(int) => Ok(int),
+            Value::Float(float) => Ok(Value::Float(float)),
+            Value::Integer(int) => Ok(Value::Integer(int)),
             _ => Err(Error::BadResponse),
         }
     }
@@ -269,6 +347,19 @@ impl Backend for ServerBackend {
 
         match value {
             Value::List(list) => Ok(list),
+            _ => Err(Error::BadResponse),
+        }
+    }
+
+    async fn length(&self, key: &[u8], key_type: Option<KeyType>) -> Result<i64> {
+        let mut args = Vec::with_capacity(1);
+        args.push(key.to_vec());
+        let req = super::make_request(CommandId::Length, Some(args), key_type);
+
+        let value = self.send_and_wait(&req.into_bytes()).await?;
+
+        match value {
+            Value::Integer(int) => Ok(int),
             _ => Err(Error::BadResponse),
         }
     }

--- a/client/src/request/append/append_bytes.rs
+++ b/client/src/request/append/append_bytes.rs
@@ -1,0 +1,67 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `set` command that will resolve to bytes when `await`ed.
+///
+/// This is returned by [`SetUnconfigured::bytes`].
+///
+/// [`SetUnconfigured::bytes`]: struct.SetUnconfigured.html#method.bytes
+pub struct AppendBytes<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, Vec<u8>, B::Error>,
+    key: Option<K>,
+    value: Option<Vec<u8>>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> AppendBytes<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K, value: Vec<u8>) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+            value: Some(value),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
+    for AppendBytes<'a, B, K>
+{
+    type Output = Result<Vec<u8>, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+            let value = self.value.take().expect("value only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let key = key.as_ref();
+                let value = backend.append(key, Value::Bytes(value)).await?;
+
+                match value {
+                    Value::Bytes(bytes) => Ok(bytes),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AppendBytes;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(AppendBytes<MemoryBackend, Vec<u8>>: Send);
+}

--- a/client/src/request/append/append_list.rs
+++ b/client/src/request/append/append_list.rs
@@ -1,0 +1,67 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `set` command that will resolve to bytes when `await`ed.
+///
+/// This is returned by [`SetUnconfigured::bytes`].
+///
+/// [`SetUnconfigured::bytes`]: struct.SetUnconfigured.html#method.bytes
+pub struct AppendList<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, Vec<Vec<u8>>, B::Error>,
+    key: Option<K>,
+    value: Option<Vec<Vec<u8>>>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> AppendList<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K, value: Vec<Vec<u8>>) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+            value: Some(value),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
+    for AppendList<'a, B, K>
+{
+    type Output = Result<Vec<Vec<u8>>, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+            let value = self.value.take().expect("value only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let key = key.as_ref();
+                let value = backend.append(key, Value::List(value)).await?;
+
+                match value {
+                    Value::List(list) => Ok(list),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AppendList;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(AppendList<MemoryBackend, Vec<u8>>: Send);
+}

--- a/client/src/request/append/append_string.rs
+++ b/client/src/request/append/append_string.rs
@@ -1,0 +1,67 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `set` command that will resolve to bytes when `await`ed.
+///
+/// This is returned by [`SetUnconfigured::bytes`].
+///
+/// [`SetUnconfigured::bytes`]: struct.SetUnconfigured.html#method.bytes
+pub struct AppendString<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, String, B::Error>,
+    key: Option<K>,
+    value: Option<String>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> AppendString<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K, value: String) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+            value: Some(value),
+        }
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
+    for AppendString<'a, B, K>
+{
+    type Output = Result<String, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+            let value = self.value.take().expect("value only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let key = key.as_ref();
+                let value = backend.append(key, Value::String(value)).await?;
+
+                match value {
+                    Value::String(string) => Ok(string),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AppendString;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(AppendString<MemoryBackend, Vec<u8>>: Send);
+}

--- a/client/src/request/append/mod.rs
+++ b/client/src/request/append/mod.rs
@@ -1,0 +1,71 @@
+mod append_bytes;
+mod append_list;
+mod append_string;
+
+pub use self::{append_bytes::AppendBytes, append_list::AppendList, append_string::AppendString};
+
+use crate::Backend;
+use std::sync::Arc;
+
+/// A request to append to a key.
+pub struct AppendUnconfigured<B: Backend, K: AsRef<[u8]> + Send + Unpin> {
+    backend: Arc<B>,
+    key: K,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> AppendUnconfigured<B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
+        Self { backend, key }
+    }
+
+    /// Append bytes to a bytes key.
+    ///
+    /// The returned struct, when `await`ed, will resolve to the new value on
+    /// success.
+    ///
+    /// # Examples
+    ///
+    /// Append `[1, 2, 3]` to the key "foo":
+    ///
+    /// ```
+    /// use hop::Client;
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::memory();
+    ///
+    /// client.set("foo").bytes([1u8, 2, 3, 4, 5].as_ref()).await?;
+    ///
+    /// assert_eq!(8, client.append("foo").bytes([1u8, 2, 3].as_ref()).await?.len());
+    /// # Ok(()) }
+    /// ```
+    pub fn bytes(self, bytes: impl Into<Vec<u8>>) -> AppendBytes<'a, B, K> {
+        AppendBytes::new(self.backend, self.key, bytes.into())
+    }
+
+    /// Append one or more items to a list.
+    pub fn list(self, list: impl Into<Vec<Vec<u8>>>) -> AppendList<'a, B, K> {
+        AppendList::new(self.backend, self.key, list.into())
+    }
+
+    /// An alias for [`str`].
+    ///
+    /// [`str`]: #method.str
+    #[inline]
+    pub fn string(self, string: impl Into<String>) -> AppendString<'a, B, K> {
+        self.str(string)
+    }
+
+    /// Append to a string.
+    pub fn str(self, string: impl Into<String>) -> AppendString<'a, B, K> {
+        AppendString::new(self.backend, self.key, string.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AppendUnconfigured;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(AppendUnconfigured<MemoryBackend, Vec<u8>>: Send);
+}

--- a/client/src/request/decrement/decrement_float.rs
+++ b/client/src/request/decrement/decrement_float.rs
@@ -1,0 +1,73 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `get` command that will resolve to a float when `await`ed.
+///
+/// This is returned by [`GetUnconfigured::float`].
+///
+/// [`GetUnconfigured::float`]: struct.GetUnconfigured.html#method.float
+pub struct DecrementFloat<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
+    amount: f64,
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, f64, B::Error>,
+    key: Option<K>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> DecrementFloat<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
+        Self {
+            amount: 1f64,
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+        }
+    }
+
+    pub fn by(mut self, amount: f64) -> Self {
+        self.amount = amount;
+
+        self
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
+    for DecrementFloat<'a, B, K>
+{
+    type Output = Result<f64, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let amount = self.amount;
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let key = key.as_ref();
+                let value = backend.decrement_by(key, Value::Float(amount)).await?;
+
+                match value {
+                    Value::Float(float) => Ok(float),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DecrementFloat;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(DecrementFloat<MemoryBackend, Vec<u8>>: Send);
+}

--- a/client/src/request/decrement/decrement_int.rs
+++ b/client/src/request/decrement/decrement_int.rs
@@ -1,0 +1,73 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `get` command that will resolve to a float when `await`ed.
+///
+/// This is returned by [`GetUnconfigured::float`].
+///
+/// [`GetUnconfigured::float`]: struct.GetUnconfigured.html#method.float
+pub struct DecrementInteger<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
+    amount: i64,
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, i64, B::Error>,
+    key: Option<K>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> DecrementInteger<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
+        Self {
+            amount: 1,
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+        }
+    }
+
+    pub fn by(mut self, amount: i64) -> Self {
+        self.amount = amount;
+
+        self
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
+    for DecrementInteger<'a, B, K>
+{
+    type Output = Result<i64, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let amount = self.amount;
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let key = key.as_ref();
+                let value = backend.decrement_by(key, Value::Integer(amount)).await?;
+
+                match value {
+                    Value::Integer(int) => Ok(int),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DecrementInteger;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(DecrementInteger<MemoryBackend, Vec<u8>>: Send);
+}

--- a/client/src/request/decrement/mod.rs
+++ b/client/src/request/decrement/mod.rs
@@ -1,0 +1,67 @@
+mod decrement_float;
+mod decrement_int;
+
+pub use self::{decrement_float::DecrementFloat, decrement_int::DecrementInteger};
+
+use super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+pub struct Decrement<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, Value, B::Error>,
+    key: Option<K>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> Decrement<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
+        Self {
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+        }
+    }
+
+    pub fn float(self) -> DecrementFloat<'a, B, K> {
+        DecrementFloat::new(self.backend.unwrap(), self.key.unwrap())
+    }
+
+    pub fn int(self) -> DecrementInteger<'a, B, K> {
+        DecrementInteger::new(self.backend.unwrap(), self.key.unwrap())
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
+    for Decrement<'a, B, K>
+{
+    type Output = Result<Value, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let key = key.as_ref();
+                backend.decrement(key, None).await
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Decrement;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(Decrement<MemoryBackend, Vec<u8>>: Send);
+}

--- a/client/src/request/increment/increment_float.rs
+++ b/client/src/request/increment/increment_float.rs
@@ -1,0 +1,73 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `get` command that will resolve to a float when `await`ed.
+///
+/// This is returned by [`GetUnconfigured::float`].
+///
+/// [`GetUnconfigured::float`]: struct.GetUnconfigured.html#method.float
+pub struct IncrementFloat<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
+    amount: f64,
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, f64, B::Error>,
+    key: Option<K>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> IncrementFloat<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
+        Self {
+            amount: 1f64,
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+        }
+    }
+
+    pub fn by(mut self, amount: f64) -> Self {
+        self.amount = amount;
+
+        self
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
+    for IncrementFloat<'a, B, K>
+{
+    type Output = Result<f64, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let amount = self.amount;
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let key = key.as_ref();
+                let value = backend.increment_by(key, Value::Float(amount)).await?;
+
+                match value {
+                    Value::Float(float) => Ok(float),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IncrementFloat;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(IncrementFloat<MemoryBackend, Vec<u8>>: Send);
+}

--- a/client/src/request/increment/increment_int.rs
+++ b/client/src/request/increment/increment_int.rs
@@ -1,0 +1,73 @@
+use super::super::MaybeInFlightFuture;
+use crate::Backend;
+use hop_engine::state::Value;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// A configured `get` command that will resolve to a float when `await`ed.
+///
+/// This is returned by [`GetUnconfigured::float`].
+///
+/// [`GetUnconfigured::float`]: struct.GetUnconfigured.html#method.float
+pub struct IncrementInteger<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
+    amount: i64,
+    backend: Option<Arc<B>>,
+    fut: MaybeInFlightFuture<'a, i64, B::Error>,
+    key: Option<K>,
+}
+
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> IncrementInteger<'a, B, K> {
+    pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
+        Self {
+            amount: 1,
+            backend: Some(backend),
+            fut: None,
+            key: Some(key),
+        }
+    }
+
+    pub fn by(mut self, amount: i64) -> Self {
+        self.amount = amount;
+
+        self
+    }
+}
+
+impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
+    for IncrementInteger<'a, B, K>
+{
+    type Output = Result<i64, B::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let amount = self.amount;
+            let backend = self.backend.take().expect("backend only taken once");
+            let key = self.key.take().expect("key only taken once");
+
+            self.fut.replace(Box::pin(async move {
+                let key = key.as_ref();
+                let value = backend.increment_by(key, Value::Integer(amount)).await?;
+
+                match value {
+                    Value::Integer(int) => Ok(int),
+                    _ => unreachable!(),
+                }
+            }));
+        }
+
+        self.fut.as_mut().expect("future exists").as_mut().poll(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IncrementInteger;
+    use crate::backend::MemoryBackend;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(IncrementInteger<MemoryBackend, Vec<u8>>: Send);
+}

--- a/client/src/request/increment/mod.rs
+++ b/client/src/request/increment/mod.rs
@@ -1,6 +1,11 @@
+mod increment_float;
+mod increment_int;
+
+pub use self::{increment_float::IncrementFloat, increment_int::IncrementInteger};
+
 use super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::KeyType;
+use hop_engine::state::{KeyType, Value};
 use std::{
     future::Future,
     pin::Pin,
@@ -10,7 +15,7 @@ use std::{
 
 pub struct Increment<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
-    fut: MaybeInFlightFuture<'a, i64, B::Error>,
+    fut: MaybeInFlightFuture<'a, Value, B::Error>,
     key: Option<K>,
     kind: Option<KeyType>,
 }
@@ -19,38 +24,35 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> Increment<'a, B, K> {
     pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
         Self {
             backend: Some(backend),
+            fut: None,
             key: Some(key),
             kind: None,
-            fut: None,
         }
     }
 
-    pub fn float(mut self) -> Self {
-        self.kind.replace(KeyType::Float);
-
-        self
+    pub fn float(self) -> IncrementFloat<'a, B, K> {
+        IncrementFloat::new(self.backend.unwrap(), self.key.unwrap())
     }
 
-    pub fn int(mut self) -> Self {
-        self.kind.replace(KeyType::Integer);
-
-        self
+    pub fn int(self) -> IncrementInteger<'a, B, K> {
+        IncrementInteger::new(self.backend.unwrap(), self.key.unwrap())
     }
 }
 
 impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
     for Increment<'a, B, K>
 {
-    type Output = Result<i64, B::Error>;
+    type Output = Result<Value, B::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if self.fut.is_none() {
-            let backend = { self.backend.take().expect("backend only taken once") };
+            let backend = self.backend.take().expect("backend only taken once");
             let key = self.key.take().expect("key only taken once");
             let kind = self.kind.take();
 
             self.fut.replace(Box::pin(async move {
                 let key = key.as_ref();
+
                 backend.increment(key, kind).await
             }));
         }

--- a/client/src/request/length.rs
+++ b/client/src/request/length.rs
@@ -8,50 +8,68 @@ use std::{
     task::{Context, Poll},
 };
 
-pub struct Decrement<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
+/// Request to retrieve the length of a key, optionally only if it is of a
+/// certain type.
+pub struct Length<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
     fut: MaybeInFlightFuture<'a, i64, B::Error>,
     key: Option<K>,
     kind: Option<KeyType>,
 }
 
-impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> Decrement<'a, B, K> {
+impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> Length<'a, B, K> {
     pub(crate) fn new(backend: Arc<B>, key: K) -> Self {
         Self {
             backend: Some(backend),
-            fut: None,
             key: Some(key),
             kind: None,
+            fut: None,
         }
     }
 
-    pub fn float(mut self) -> Self {
-        self.kind.replace(KeyType::Float);
+    /// Retrieve the length *only* if the key is some bytes.
+    pub fn bytes(mut self) -> Self {
+        self.kind.replace(KeyType::Bytes);
 
         self
     }
 
-    pub fn int(mut self) -> Self {
-        self.kind.replace(KeyType::Integer);
+    /// Retrieve the length *only* if the key is list.
+    pub fn list(mut self) -> Self {
+        self.kind.replace(KeyType::List);
+
+        self
+    }
+
+    /// An alais for [`str`].
+    ///
+    /// [`str`]: #method.str
+    pub fn string(self) -> Self {
+        self.str()
+    }
+
+    /// Retrieve the length *only* if the key is a string.
+    pub fn str(mut self) -> Self {
+        self.kind.replace(KeyType::String);
 
         self
     }
 }
 
 impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Future
-    for Decrement<'a, B, K>
+    for Length<'a, B, K>
 {
     type Output = Result<i64, B::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if self.fut.is_none() {
-            let backend = self.backend.take().expect("backend only taken once");
+            let backend = { self.backend.take().expect("backend only taken once") };
             let key = self.key.take().expect("key only taken once");
             let kind = self.kind.take();
 
             self.fut.replace(Box::pin(async move {
                 let key = key.as_ref();
-                backend.decrement(key, kind).await
+                backend.length(key, kind).await
             }));
         }
 
@@ -61,9 +79,9 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 
 #[cfg(test)]
 mod tests {
-    use super::Decrement;
+    use super::Length;
     use crate::backend::MemoryBackend;
     use static_assertions::assert_impl_all;
 
-    assert_impl_all!(Decrement<MemoryBackend, Vec<u8>>: Send);
+    assert_impl_all!(Length<MemoryBackend, Vec<u8>>: Send);
 }

--- a/client/src/request/mod.rs
+++ b/client/src/request/mod.rs
@@ -1,3 +1,4 @@
+pub mod append;
 pub mod exists;
 pub mod get;
 pub mod is;
@@ -8,6 +9,7 @@ mod delete;
 mod echo;
 mod increment;
 mod keys;
+mod length;
 mod rename;
 mod stats;
 mod r#type;
@@ -20,6 +22,7 @@ pub use self::{
     increment::Increment,
     is::Is,
     keys::Keys,
+    length::Length,
     r#type::Type,
     rename::Rename,
     stats::Stats,


### PR DESCRIPTION
Implement the missing commands:

- append
- decrement:by
- increment:by
- length

Closes #1.

Tests are included.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>