### PR TITLE
actions: run audit only when cargo is changed

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -8,6 +8,9 @@ on:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
   pull_request:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
 
 jobs:
   audit:


### PR DESCRIPTION
Run the audit action only when one of the `Cargo.lock` or `Cargo.toml`
files have changed.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>