### PR TITLE
engine/command/request: add a builder

### DIFF
--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -10,10 +10,7 @@ pub use self::server::ServerBackend;
 
 use crate::model::StatsData;
 use async_trait::async_trait;
-use hop_engine::{
-    command::{CommandId, Request},
-    state::{KeyType, Value},
-};
+use hop_engine::state::{KeyType, Value};
 
 #[async_trait]
 pub trait Backend: Send + Sync {
@@ -101,16 +98,4 @@ pub trait Backend: Send + Sync {
     async fn stats(&self) -> Result<StatsData, Self::Error>
     where
         Self: Sized;
-}
-
-fn make_request(
-    cmd_id: CommandId,
-    args: Option<Vec<Vec<u8>>>,
-    key_type: Option<KeyType>,
-) -> Request {
-    if let Some(key_type) = key_type {
-        Request::new_with_type(cmd_id, args, key_type)
-    } else {
-        Request::new(cmd_id, args)
-    }
 }

--- a/engine/benches/bench_command.rs
+++ b/engine/benches/bench_command.rs
@@ -6,7 +6,7 @@ extern crate test;
 
 use alloc::vec::Vec;
 use hop_engine::{
-    command::{CommandId, Request},
+    command::{request::RequestBuilder, CommandId},
     Hop,
 };
 use test::Bencher;
@@ -14,8 +14,9 @@ use test::Bencher;
 #[bench]
 fn bench_increment(b: &mut Bencher) {
     let hop = Hop::new();
-    let args = [b"foo".to_vec()].to_vec();
-    let req = Request::new(CommandId::Increment, Some(args));
+    let mut builder = RequestBuilder::new(CommandId::Increment);
+    builder.bytes(b"foo".as_ref()).unwrap();
+    let req = builder.into_request();
     let mut resp = Vec::new();
 
     b.iter(|| {

--- a/engine/src/command/impl/decrement.rs
+++ b/engine/src/command/impl/decrement.rs
@@ -19,7 +19,7 @@ impl Dispatch for Decrement {
 mod tests {
     use super::Decrement;
     use crate::{
-        command::{CommandId, Dispatch, DispatchError, Request, Response},
+        command::{request::RequestBuilder, CommandId, Dispatch, DispatchError, Response},
         state::object::Integer,
         Hop,
     };
@@ -27,9 +27,9 @@ mod tests {
 
     #[test]
     fn test_decrement() {
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        let req = Request::new(CommandId::Decrement, Some(args));
+        let mut builder = RequestBuilder::new(CommandId::Decrement);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        let req = builder.into_request();
         let hop = Hop::new();
         let mut resp = Vec::new();
 
@@ -43,7 +43,7 @@ mod tests {
 
     #[test]
     fn test_no_key() {
-        let req = Request::new(CommandId::Decrement, None);
+        let req = RequestBuilder::new(CommandId::Decrement).into_request();
         let hop = Hop::new();
         let mut resp = Vec::new();
 

--- a/engine/src/command/impl/decrement_by.rs
+++ b/engine/src/command/impl/decrement_by.rs
@@ -76,7 +76,7 @@ impl Dispatch for DecrementBy {
 mod tests {
     use super::DecrementBy;
     use crate::{
-        command::{request, CommandId, Dispatch, DispatchError, Request, Response},
+        command::{request::RequestBuilder, CommandId, Dispatch, DispatchError, Response},
         state::{object::Integer, Value},
         Hop,
     };
@@ -84,10 +84,10 @@ mod tests {
 
     #[test]
     fn test_decrement_by() {
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        request::write_value_to_args(Value::Integer(3), &mut args);
-        let req = Request::new(CommandId::DecrementBy, Some(args));
+        let mut builder = RequestBuilder::new(CommandId::DecrementBy);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        assert!(builder.value(Value::Integer(3)).is_ok());
+        let req = builder.into_request();
         let hop = Hop::new();
         let mut resp = Vec::new();
 
@@ -101,7 +101,7 @@ mod tests {
 
     #[test]
     fn test_no_key() {
-        let req = Request::new(CommandId::Decrement, None);
+        let req = RequestBuilder::new(CommandId::Decrement).into_request();
         let hop = Hop::new();
         let mut resp = Vec::new();
 
@@ -113,10 +113,9 @@ mod tests {
 
     #[test]
     fn test_no_amount() {
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-
-        let req = Request::new(CommandId::DecrementBy, Some(args));
+        let mut builder = RequestBuilder::new(CommandId::DecrementBy);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        let req = builder.into_request();
         let hop = Hop::new();
         let mut resp = Vec::new();
 

--- a/engine/src/command/impl/delete.rs
+++ b/engine/src/command/impl/delete.rs
@@ -26,23 +26,22 @@ impl Dispatch for Delete {
 mod tests {
     use super::Delete;
     use crate::{
-        command::{CommandId, Dispatch, DispatchError, Request, Response},
+        command::{request::RequestBuilder, CommandId, Dispatch, DispatchError, Response},
         state::{KeyType, Value},
         Hop,
     };
     use alloc::vec::Vec;
 
-    fn args() -> Vec<Vec<u8>> {
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
+    fn builder() -> RequestBuilder {
+        let mut builder = RequestBuilder::new(CommandId::DecrementBy);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
 
-        args
+        builder
     }
 
     #[test]
     fn test_valid() {
-        let args = args();
-        let req = Request::new(CommandId::Delete, Some(args));
+        let req = builder().into_request();
         let mut resp = Vec::new();
 
         let hop = Hop::new();
@@ -56,8 +55,7 @@ mod tests {
 
     #[test]
     fn test_nonexistent() {
-        let args = args();
-        let req = Request::new(CommandId::Delete, Some(args));
+        let req = builder().into_request();
         let mut resp = Vec::new();
 
         let hop = Hop::new();
@@ -70,8 +68,9 @@ mod tests {
 
     #[test]
     fn test_key_type_specified() {
-        let args = args();
-        let req = Request::new_with_type(CommandId::Delete, Some(args), KeyType::Bytes);
+        let mut builder = builder();
+        builder.key_type(KeyType::Bytes);
+        let req = builder.into_request();
         let mut resp = Vec::new();
 
         let hop = Hop::new();
@@ -84,7 +83,7 @@ mod tests {
 
     #[test]
     fn test_no_arguments() {
-        let req = Request::new(CommandId::Delete, None);
+        let req = RequestBuilder::new(CommandId::Delete).into_request();
         let mut resp = Vec::new();
 
         let hop = Hop::new();

--- a/engine/src/command/impl/echo.rs
+++ b/engine/src/command/impl/echo.rs
@@ -23,7 +23,7 @@ impl Dispatch for Echo {
 mod tests {
     use super::Echo;
     use crate::{
-        command::{response, CommandId, Dispatch, Request},
+        command::{request::RequestBuilder, response, CommandId, Dispatch},
         Hop,
     };
     use alloc::vec::Vec;
@@ -31,41 +31,41 @@ mod tests {
     #[test]
     fn test_input() {
         let hop = Hop::new();
-        let mut args = Vec::new();
-        args.push(b"hopdb".to_vec());
 
-        let req = Request::new(CommandId::Echo, Some(args.clone()));
+        let mut builder = RequestBuilder::new(CommandId::Echo);
+        assert!(builder.bytes(b"hopdb".as_ref()).is_ok());
+        let req = builder.clone().into_request();
 
         let mut expected = Vec::new();
         let mut resp = Vec::new();
 
         assert!(Echo::dispatch(&hop, &req, &mut resp).is_ok());
-        response::write_list(&mut expected, args.as_slice());
+        response::write_list(&mut expected, [b"hopdb"].as_ref());
         assert_eq!(resp, expected);
 
         expected.clear();
         resp.clear();
 
-        args.push(b"hop".to_vec());
-        let req = Request::new(CommandId::Echo, Some(args.clone()));
+        assert!(builder.bytes(b"hop".as_ref()).is_ok());
+        let req = builder.into_request();
 
         assert!(Echo::dispatch(&hop, &req, &mut resp).is_ok());
-        response::write_list(&mut expected, args.as_slice());
+        response::write_list(&mut expected, [b"hopdb".as_ref(), b"hop".as_ref()].as_ref());
         assert_eq!(resp, expected);
     }
 
     #[test]
     fn test_empty() {
-        let hop = Hop::new();
-        let req = Request::new(CommandId::Echo, None);
+        let req = RequestBuilder::new(CommandId::Echo).into_request();
 
-        let args: &[Vec<_>] = &[];
+        let hop = Hop::new();
+        let empty_slice: &[Vec<_>] = &[];
 
         let mut expected = Vec::new();
         let mut resp = Vec::new();
 
         assert!(Echo::dispatch(&hop, &req, &mut resp).is_ok());
-        response::write_list(&mut expected, args);
+        response::write_list(&mut expected, empty_slice);
         assert_eq!(resp, expected);
     }
 }

--- a/engine/src/command/impl/exists.rs
+++ b/engine/src/command/impl/exists.rs
@@ -25,27 +25,19 @@ impl Dispatch for Exists {
 mod tests {
     use super::Exists;
     use crate::{
-        command::{CommandId, Dispatch, DispatchError, Request, Response},
+        command::{request::RequestBuilder, CommandId, Dispatch, DispatchError, Response},
         state::{KeyType, Value},
         Hop,
     };
     use alloc::vec::Vec;
 
-    fn args() -> Vec<Vec<u8>> {
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        args.push(b"bar".to_vec());
-
-        args
-    }
-
     #[test]
     fn test_one_key() {
-        let mut args = args();
-        args.pop();
-        let req = Request::new(CommandId::Exists, Some(args));
-        let mut resp = Vec::new();
+        let mut builder = RequestBuilder::new(CommandId::Exists);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        let req = builder.into_request();
 
+        let mut resp = Vec::new();
         let hop = Hop::new();
         hop.state()
             .insert(b"foo".to_vec(), Value::Bytes([1, 2, 3].to_vec()));
@@ -56,10 +48,12 @@ mod tests {
 
     #[test]
     fn test_two_keys_both_exist() {
-        let args = args();
-        let req = Request::new(CommandId::Exists, Some(args));
-        let mut resp = Vec::new();
+        let mut builder = RequestBuilder::new(CommandId::Exists);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        assert!(builder.bytes(b"bar".as_ref()).is_ok());
+        let req = builder.into_request();
 
+        let mut resp = Vec::new();
         let hop = Hop::new();
         hop.state()
             .insert(b"foo".to_vec(), Value::Bytes([1, 2, 3].to_vec()));
@@ -72,10 +66,12 @@ mod tests {
 
     #[test]
     fn test_two_keys_one_exists() {
-        let args = args();
-        let req = Request::new(CommandId::Exists, Some(args));
-        let mut resp = Vec::new();
+        let mut builder = RequestBuilder::new(CommandId::Exists);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        assert!(builder.bytes(b"bar".as_ref()).is_ok());
+        let req = builder.into_request();
 
+        let mut resp = Vec::new();
         let hop = Hop::new();
         hop.state()
             .insert(b"foo".to_vec(), Value::Bytes([1, 2, 3].to_vec()));
@@ -86,11 +82,11 @@ mod tests {
 
     #[test]
     fn test_one_key_doesnt_exist() {
-        let mut args = args();
-        args.pop();
-        let req = Request::new(CommandId::Exists, Some(args));
-        let mut resp = Vec::new();
+        let mut builder = RequestBuilder::new(CommandId::Exists);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        let req = builder.into_request();
 
+        let mut resp = Vec::new();
         let hop = Hop::new();
 
         assert!(Exists::dispatch(&hop, &req, &mut resp).is_ok());
@@ -99,7 +95,8 @@ mod tests {
 
     #[test]
     fn test_no_arguments() {
-        let req = Request::new(CommandId::Exists, None);
+        let req = RequestBuilder::new(CommandId::Exists).into_request();
+
         let mut resp = Vec::new();
 
         let hop = Hop::new();
@@ -111,7 +108,12 @@ mod tests {
 
     #[test]
     fn test_key_type_specified() {
-        let req = Request::new_with_type(CommandId::Exists, Some(args()), KeyType::List);
+        let mut builder = RequestBuilder::new(CommandId::Exists);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        assert!(builder.bytes(b"bar".as_ref()).is_ok());
+        builder.key_type(KeyType::List);
+        let req = builder.into_request();
+
         let mut resp = Vec::new();
 
         let hop = Hop::new();

--- a/engine/src/command/impl/get.rs
+++ b/engine/src/command/impl/get.rs
@@ -30,7 +30,7 @@ impl Dispatch for Get {
 mod tests {
     use super::Get;
     use crate::{
-        command::{CommandId, Dispatch, DispatchError, Request, Response},
+        command::{request::RequestBuilder, CommandId, Dispatch, DispatchError, Response},
         state::{KeyType, Value},
         Hop,
     };
@@ -38,12 +38,13 @@ mod tests {
 
     #[test]
     fn test_bool() {
+        let mut builder = RequestBuilder::new(CommandId::Get);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        let req = builder.into_request();
+
+        let mut resp = Vec::new();
         let hop = Hop::new();
         hop.state().insert(b"foo".to_vec(), Value::Boolean(false));
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        let req = Request::new(CommandId::Get, Some(args));
-        let mut resp = Vec::new();
 
         assert!(Get::dispatch(&hop, &req, &mut resp).is_ok());
         assert_eq!(resp, Response::from(false).as_bytes());
@@ -51,13 +52,14 @@ mod tests {
 
     #[test]
     fn test_bool_specified_key_type() {
+        let mut builder = RequestBuilder::new(CommandId::Get);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        builder.key_type(KeyType::Boolean);
+        let req = builder.into_request();
+
+        let mut resp = Vec::new();
         let hop = Hop::new();
         hop.state().insert(b"foo".to_vec(), Value::Boolean(true));
-
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        let req = Request::new_with_type(CommandId::Get, Some(args), KeyType::Boolean);
-        let mut resp = Vec::new();
 
         assert!(Get::dispatch(&hop, &req, &mut resp).is_ok());
         assert_eq!(resp, Response::from(true).as_bytes());
@@ -65,12 +67,13 @@ mod tests {
 
     #[test]
     fn test_int() {
+        let mut builder = RequestBuilder::new(CommandId::Get);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        let req = builder.into_request();
+
+        let mut resp = Vec::new();
         let hop = Hop::new();
         hop.state().insert(b"foo".to_vec(), Value::Integer(123));
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        let req = Request::new(CommandId::Get, Some(args));
-        let mut resp = Vec::new();
 
         assert!(Get::dispatch(&hop, &req, &mut resp).is_ok());
         assert_eq!(resp, Response::from(123).as_bytes());
@@ -78,9 +81,10 @@ mod tests {
 
     #[test]
     fn test_no_key() {
-        let hop = Hop::new();
-        let req = Request::new(CommandId::Get, None);
+        let req = RequestBuilder::new(CommandId::Get).into_request();
+
         let mut resp = Vec::new();
+        let hop = Hop::new();
 
         assert_eq!(
             DispatchError::KeyUnspecified,
@@ -90,11 +94,12 @@ mod tests {
 
     #[test]
     fn test_key_nonexistent() {
-        let hop = Hop::new();
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        let req = Request::new(CommandId::Get, Some(args));
+        let mut builder = RequestBuilder::new(CommandId::Get);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        let req = builder.into_request();
+
         let mut resp = Vec::new();
+        let hop = Hop::new();
 
         assert_eq!(
             DispatchError::KeyNonexistent,
@@ -104,12 +109,14 @@ mod tests {
 
     #[test]
     fn test_key_type_different() {
+        let mut builder = RequestBuilder::new(CommandId::Get);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        builder.key_type(KeyType::Boolean);
+        let req = builder.into_request();
+
+        let mut resp = Vec::new();
         let hop = Hop::new();
         hop.state().insert(b"foo".to_vec(), Value::Integer(123));
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        let req = Request::new_with_type(CommandId::Get, Some(args), KeyType::Boolean);
-        let mut resp = Vec::new();
 
         assert_eq!(
             DispatchError::KeyTypeDifferent,

--- a/engine/src/command/impl/increment.rs
+++ b/engine/src/command/impl/increment.rs
@@ -19,7 +19,7 @@ impl Dispatch for Increment {
 mod tests {
     use super::Increment;
     use crate::{
-        command::{CommandId, Dispatch, DispatchError, Request, Response},
+        command::{request::RequestBuilder, CommandId, Dispatch, DispatchError, Response},
         state::object::Integer,
         Hop,
     };
@@ -27,9 +27,9 @@ mod tests {
 
     #[test]
     fn test_increment() {
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        let req = Request::new(CommandId::Increment, Some(args));
+        let mut builder = RequestBuilder::new(CommandId::Increment);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        let req = builder.into_request();
         let hop = Hop::new();
         let mut resp = Vec::new();
 
@@ -43,7 +43,7 @@ mod tests {
 
     #[test]
     fn test_no_key() {
-        let req = Request::new(CommandId::Increment, None);
+        let req = RequestBuilder::new(CommandId::Increment).into_request();
         let hop = Hop::new();
         let mut resp = Vec::new();
 

--- a/engine/src/command/impl/increment_by.rs
+++ b/engine/src/command/impl/increment_by.rs
@@ -76,7 +76,7 @@ impl Dispatch for IncrementBy {
 mod tests {
     use super::IncrementBy;
     use crate::{
-        command::{request, CommandId, Dispatch, DispatchError, Request, Response},
+        command::{request::RequestBuilder, CommandId, Dispatch, DispatchError, Response},
         state::{object::Integer, Value},
         Hop,
     };
@@ -84,10 +84,10 @@ mod tests {
 
     #[test]
     fn test_decrement_by() {
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        request::write_value_to_args(Value::Integer(3), &mut args);
-        let req = Request::new(CommandId::IncrementBy, Some(args));
+        let mut builder = RequestBuilder::new(CommandId::IncrementBy);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        assert!(builder.value(Value::Integer(3)).is_ok());
+        let req = builder.into_request();
         let hop = Hop::new();
         let mut resp = Vec::new();
 
@@ -101,7 +101,7 @@ mod tests {
 
     #[test]
     fn test_no_key() {
-        let req = Request::new(CommandId::Decrement, None);
+        let req = RequestBuilder::new(CommandId::Decrement).into_request();
         let hop = Hop::new();
         let mut resp = Vec::new();
 
@@ -113,10 +113,10 @@ mod tests {
 
     #[test]
     fn test_no_amount() {
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
+        let mut builder = RequestBuilder::new(CommandId::IncrementBy);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        let req = builder.into_request();
 
-        let req = Request::new(CommandId::IncrementBy, Some(args));
         let hop = Hop::new();
         let mut resp = Vec::new();
 

--- a/engine/src/command/impl/is.rs
+++ b/engine/src/command/impl/is.rs
@@ -27,7 +27,7 @@ impl Dispatch for Is {
 mod tests {
     use super::Is;
     use crate::{
-        command::{CommandId, Dispatch, DispatchError, Request, Response},
+        command::{request::RequestBuilder, CommandId, Dispatch, DispatchError, Response},
         state::{KeyType, Value},
         Hop,
     };
@@ -35,12 +35,14 @@ mod tests {
 
     #[test]
     fn test_one_arg() {
-        let hop = Hop::new();
-        let mut args = Vec::new();
-        hop.state().key_or_insert_with(b"foo", Value::string);
-        args.push(b"foo".to_vec());
+        let mut builder = RequestBuilder::new(CommandId::Is);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        builder.key_type(KeyType::String);
+        let req = builder.into_request();
 
-        let req = Request::new_with_type(CommandId::Is, Some(args), KeyType::String);
+        let hop = Hop::new();
+        hop.state().key_or_insert_with(b"foo", Value::string);
+
         let mut resp = Vec::new();
 
         assert!(Is::dispatch(&hop, &req, &mut resp).is_ok());
@@ -49,14 +51,16 @@ mod tests {
 
     #[test]
     fn test_two_args() {
-        let hop = Hop::new();
-        let mut args = Vec::new();
-        hop.state().key_or_insert_with(b"foo", Value::string);
-        args.push(b"foo".to_vec());
-        hop.state().key_or_insert_with(b"bar", Value::string);
-        args.push(b"bar".to_vec());
+        let mut builder = RequestBuilder::new(CommandId::Is);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        assert!(builder.bytes(b"bar".as_ref()).is_ok());
+        builder.key_type(KeyType::String);
+        let req = builder.into_request();
 
-        let req = Request::new_with_type(CommandId::Is, Some(args), KeyType::String);
+        let hop = Hop::new();
+        hop.state().key_or_insert_with(b"foo", Value::string);
+        hop.state().key_or_insert_with(b"bar", Value::string);
+
         let mut resp = Vec::new();
 
         assert!(Is::dispatch(&hop, &req, &mut resp).is_ok());
@@ -65,14 +69,16 @@ mod tests {
 
     #[test]
     fn test_two_mismatched() {
-        let hop = Hop::new();
-        let mut args = Vec::new();
-        hop.state().key_or_insert_with(b"foo", Value::string);
-        args.push(b"foo".to_vec());
-        hop.state().key_or_insert_with(b"bar", Value::integer);
-        args.push(b"bar".to_vec());
+        let mut builder = RequestBuilder::new(CommandId::Is);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        assert!(builder.bytes(b"bar".as_ref()).is_ok());
+        builder.key_type(KeyType::String);
+        let req = builder.into_request();
 
-        let req = Request::new_with_type(CommandId::Is, Some(args), KeyType::String);
+        let hop = Hop::new();
+        hop.state().key_or_insert_with(b"foo", Value::string);
+        hop.state().key_or_insert_with(b"bar", Value::integer);
+
         let mut resp = Vec::new();
 
         assert!(Is::dispatch(&hop, &req, &mut resp).is_ok());
@@ -81,9 +87,12 @@ mod tests {
 
     #[test]
     fn test_no_arguments() {
+        let mut builder = RequestBuilder::new(CommandId::Is);
+        builder.key_type(KeyType::Bytes);
+        let req = builder.into_request();
+
         let hop = Hop::new();
 
-        let req = Request::new_with_type(CommandId::Is, None, KeyType::Bytes);
         let mut resp = Vec::new();
 
         assert!(matches!(
@@ -94,11 +103,12 @@ mod tests {
 
     #[test]
     fn test_key_type_unspecified() {
-        let hop = Hop::new();
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
+        let mut builder = RequestBuilder::new(CommandId::Is);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        let req = builder.into_request();
 
-        let req = Request::new(CommandId::Is, Some(args));
+        let hop = Hop::new();
+
         let mut resp = Vec::new();
 
         assert!(matches!(

--- a/engine/src/command/impl/keys.rs
+++ b/engine/src/command/impl/keys.rs
@@ -37,7 +37,7 @@ impl Dispatch for Keys {
 mod tests {
     use super::Keys;
     use crate::{
-        command::{CommandId, Dispatch, DispatchError, Request, Response},
+        command::{request::RequestBuilder, CommandId, Dispatch, DispatchError, Response},
         state::{KeyType, Value},
         Hop,
     };
@@ -46,13 +46,12 @@ mod tests {
 
     #[test]
     fn test_map_no_key_type_two_pairs() {
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        let hop = Hop::new();
-        let req = Request::new(CommandId::Keys, Some(args));
+        let mut builder = RequestBuilder::new(CommandId::Keys);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        let req = builder.into_request();
 
         let mut resp = Vec::new();
-
+        let hop = Hop::new();
         let map = DashMap::new();
         map.insert(b"key1".to_vec(), b"value2".to_vec());
         map.insert(b"key2".to_vec(), b"value2".to_vec());
@@ -66,13 +65,13 @@ mod tests {
 
     #[test]
     fn test_map_key_type() {
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        let hop = Hop::new();
-        let req = Request::new_with_type(CommandId::Keys, Some(args), KeyType::Map);
+        let mut builder = RequestBuilder::new(CommandId::Keys);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        builder.key_type(KeyType::Map);
+        let req = builder.into_request();
 
         let mut resp = Vec::new();
-
+        let hop = Hop::new();
         let map = DashMap::new();
         map.insert(b"key".to_vec(), b"value".to_vec());
         hop.state().insert(b"foo".to_vec(), Value::Map(map));
@@ -83,12 +82,13 @@ mod tests {
 
     #[test]
     fn test_key_type_invalid() {
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        let hop = Hop::new();
-        let req = Request::new_with_type(CommandId::Keys, Some(args), KeyType::Integer);
+        let mut builder = RequestBuilder::new(CommandId::Keys);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        builder.key_type(KeyType::Integer);
+        let req = builder.into_request();
 
         let mut resp = Vec::new();
+        let hop = Hop::new();
 
         assert_eq!(
             DispatchError::KeyTypeInvalid,
@@ -98,12 +98,13 @@ mod tests {
 
     #[test]
     fn test_key_type_different() {
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        let hop = Hop::new();
-        let req = Request::new_with_type(CommandId::Keys, Some(args), KeyType::Map);
+        let mut builder = RequestBuilder::new(CommandId::Keys);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        builder.key_type(KeyType::Map);
+        let req = builder.into_request();
 
         let mut resp = Vec::new();
+        let hop = Hop::new();
 
         hop.state().insert(b"foo".to_vec(), Value::Integer(1));
         assert_eq!(

--- a/engine/src/command/impl/set.rs
+++ b/engine/src/command/impl/set.rs
@@ -169,7 +169,7 @@ impl Dispatch for Set {
 mod tests {
     use super::Set;
     use crate::{
-        command::{CommandId, Dispatch, DispatchError, Request, Response},
+        command::{request::RequestBuilder, CommandId, Dispatch, DispatchError, Response},
         state::{
             object::{Boolean, Bytes, Float, Integer, List, Map, Set as SetObject, Str},
             KeyType,
@@ -181,8 +181,9 @@ mod tests {
     #[test]
     fn test_types_no_arg() {
         let hop = Hop::new();
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
+
+        let mut builder = RequestBuilder::new(CommandId::Set);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
         let mut resp = Vec::new();
 
         let types = [
@@ -197,7 +198,9 @@ mod tests {
         ];
 
         for key_type in &types {
-            let req = Request::new_with_type(CommandId::Set, Some(args.clone()), *key_type);
+            let mut builder = builder.clone();
+            builder.key_type(*key_type);
+            let req = builder.into_request();
 
             assert_eq!(
                 Set::dispatch(&hop, &req, &mut resp).unwrap_err(),
@@ -210,11 +213,14 @@ mod tests {
 
     #[test]
     fn test_bool() {
+        let mut builder = RequestBuilder::new(CommandId::Set);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        assert!(builder.bytes([1].as_ref()).is_ok());
+        builder.key_type(KeyType::Boolean);
+        let req = builder.into_request();
+
         let hop = Hop::new();
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        args.push([1].to_vec());
-        let req = Request::new_with_type(CommandId::Set, Some(args), KeyType::Boolean);
+
         let mut resp = Vec::new();
 
         assert!(Set::dispatch(&hop, &req, &mut resp).is_ok());
@@ -224,11 +230,14 @@ mod tests {
 
     #[test]
     fn test_bytes() {
+        let mut builder = RequestBuilder::new(CommandId::Set);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        assert!(builder.bytes(b"bar baz".to_vec()).is_ok());
+        builder.key_type(KeyType::Bytes);
+        let req = builder.into_request();
+
         let hop = Hop::new();
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        args.push(b"bar baz".to_vec());
-        let req = Request::new_with_type(CommandId::Set, Some(args), KeyType::Bytes);
+
         let mut resp = Vec::new();
 
         assert!(Set::dispatch(&hop, &req, &mut resp).is_ok());
@@ -238,11 +247,14 @@ mod tests {
 
     #[test]
     fn test_float() {
+        let mut builder = RequestBuilder::new(CommandId::Set);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        assert!(builder.bytes(2f64.to_be_bytes().to_vec()).is_ok());
+        builder.key_type(KeyType::Float);
+        let req = builder.into_request();
+
         let hop = Hop::new();
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        args.push(2f64.to_be_bytes().to_vec());
-        let req = Request::new_with_type(CommandId::Set, Some(args), KeyType::Float);
+
         let mut resp = Vec::new();
 
         assert!(Set::dispatch(&hop, &req, &mut resp).is_ok());
@@ -252,11 +264,14 @@ mod tests {
 
     #[test]
     fn test_int() {
+        let mut builder = RequestBuilder::new(CommandId::Set);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        assert!(builder.bytes(2i64.to_be_bytes().to_vec()).is_ok());
+        builder.key_type(KeyType::Integer);
+        let req = builder.into_request();
+
         let hop = Hop::new();
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        args.push(2i64.to_be_bytes().to_vec());
-        let req = Request::new_with_type(CommandId::Set, Some(args), KeyType::Integer);
+
         let mut resp = Vec::new();
 
         assert!(Set::dispatch(&hop, &req, &mut resp).is_ok());
@@ -266,13 +281,16 @@ mod tests {
 
     #[test]
     fn test_list_three_entries() {
+        let mut builder = RequestBuilder::new(CommandId::Set);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        assert!(builder.bytes(b"value1".to_vec()).is_ok());
+        assert!(builder.bytes(b"value2".to_vec()).is_ok());
+        assert!(builder.bytes(b"value2".to_vec()).is_ok());
+        builder.key_type(KeyType::List);
+        let req = builder.into_request();
+
         let hop = Hop::new();
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        args.push(b"value1".to_vec());
-        args.push(b"value2".to_vec());
-        args.push(b"value2".to_vec());
-        let req = Request::new_with_type(CommandId::Set, Some(args), KeyType::List);
+
         let mut resp = Vec::new();
 
         assert!(Set::dispatch(&hop, &req, &mut resp).is_ok());
@@ -287,14 +305,17 @@ mod tests {
 
     #[test]
     fn test_map_two_entries() {
+        let mut builder = RequestBuilder::new(CommandId::Set);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        assert!(builder.bytes(b"key1".to_vec()).is_ok());
+        assert!(builder.bytes(b"value1".to_vec()).is_ok());
+        assert!(builder.bytes(b"key2".to_vec()).is_ok());
+        assert!(builder.bytes(b"value2".to_vec()).is_ok());
+        builder.key_type(KeyType::Map);
+        let req = builder.into_request();
+
         let hop = Hop::new();
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        args.push(b"key1".to_vec());
-        args.push(b"value1".to_vec());
-        args.push(b"key2".to_vec());
-        args.push(b"value2".to_vec());
-        let req = Request::new_with_type(CommandId::Set, Some(args), KeyType::Map);
+
         let mut resp = Vec::new();
 
         assert!(Set::dispatch(&hop, &req, &mut resp).is_ok());
@@ -309,12 +330,15 @@ mod tests {
 
     #[test]
     fn test_set_two_entries() {
+        let mut builder = RequestBuilder::new(CommandId::Set);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        assert!(builder.bytes(b"value1".to_vec()).is_ok());
+        assert!(builder.bytes(b"value2".to_vec()).is_ok());
+        builder.key_type(KeyType::Set);
+        let req = builder.into_request();
+
         let hop = Hop::new();
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        args.push(b"value1".to_vec());
-        args.push(b"value2".to_vec());
-        let req = Request::new_with_type(CommandId::Set, Some(args), KeyType::Set);
+
         let mut resp = Vec::new();
 
         assert!(Set::dispatch(&hop, &req, &mut resp).is_ok());
@@ -329,11 +353,14 @@ mod tests {
 
     #[test]
     fn test_str() {
+        let mut builder = RequestBuilder::new(CommandId::Set);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        assert!(builder.bytes("bar".as_bytes().to_vec()).is_ok());
+        builder.key_type(KeyType::String);
+        let req = builder.into_request();
+
         let hop = Hop::new();
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        args.push("bar".as_bytes().to_vec());
-        let req = Request::new_with_type(CommandId::Set, Some(args), KeyType::String);
+
         let mut resp = Vec::new();
 
         assert!(Set::dispatch(&hop, &req, &mut resp).is_ok());

--- a/engine/src/command/impl/stats.rs
+++ b/engine/src/command/impl/stats.rs
@@ -45,7 +45,7 @@ impl Dispatch for Stats {
 mod tests {
     use super::Stats;
     use crate::{
-        command::{CommandId, Dispatch, DispatchError, Request, Response},
+        command::{request::RequestBuilder, CommandId, Dispatch, DispatchError, Response},
         metrics::Metric,
         state::KeyType,
         Hop,
@@ -54,8 +54,9 @@ mod tests {
 
     #[test]
     fn test_stats_empty() {
+        let req = RequestBuilder::new(CommandId::Stats).into_request();
+
         let hop = Hop::new();
-        let req = Request::new(CommandId::Stats, None);
         let mut resp = Vec::new();
 
         assert!(Stats::dispatch(&hop, &req, &mut resp).is_ok());
@@ -64,9 +65,9 @@ mod tests {
 
     #[test]
     fn test_stats_with_entry() {
-        let hop = Hop::new();
-        let req = Request::new(CommandId::Stats, None);
+        let req = RequestBuilder::new(CommandId::Stats).into_request();
 
+        let hop = Hop::new();
         hop.0.metrics_writer.increment(Metric::CommandsSuccessful);
 
         let mut resp = Vec::new();
@@ -79,8 +80,11 @@ mod tests {
 
     #[test]
     fn test_stats_errors_with_key_type() {
+        let mut builder = RequestBuilder::new(CommandId::Stats);
+        builder.key_type(KeyType::Map);
+        let req = builder.into_request();
+
         let hop = Hop::new();
-        let req = Request::new_with_type(CommandId::Stats, None, KeyType::Map);
         let mut resp = Vec::new();
 
         assert_eq!(

--- a/engine/src/command/impl/type.rs
+++ b/engine/src/command/impl/type.rs
@@ -29,7 +29,7 @@ impl Dispatch for Type {
 mod tests {
     use super::Type;
     use crate::{
-        command::{CommandId, Dispatch, DispatchError, Request, Response},
+        command::{request::RequestBuilder, CommandId, Dispatch, DispatchError, Response},
         state::{KeyType, Value},
         Hop,
     };
@@ -37,11 +37,12 @@ mod tests {
 
     #[test]
     fn test_key() {
+        let mut builder = RequestBuilder::new(CommandId::Type);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        assert!(builder.bytes([1].as_ref()).is_ok());
+        let req = builder.into_request();
+
         let hop = Hop::new();
-        let mut args = Vec::new();
-        args.push(b"foo".to_vec());
-        args.push([1].to_vec());
-        let req = Request::new(CommandId::Type, Some(args));
         let mut resp = Vec::new();
 
         hop.state().insert(b"foo".to_vec(), Value::Boolean(true));
@@ -52,8 +53,9 @@ mod tests {
 
     #[test]
     fn test_no_key() {
+        let req = RequestBuilder::new(CommandId::Type).into_request();
+
         let hop = Hop::new();
-        let req = Request::new(CommandId::Type, None);
         let mut resp = Vec::new();
 
         assert_eq!(
@@ -64,8 +66,11 @@ mod tests {
 
     #[test]
     fn test_key_type_specified() {
+        let mut builder = RequestBuilder::new(CommandId::Type);
+        builder.key_type(KeyType::Boolean);
+        let req = builder.into_request();
+
         let hop = Hop::new();
-        let req = Request::new(CommandId::Type, None);
         let mut resp = Vec::new();
 
         assert_eq!(

--- a/engine/src/command/request/builder.rs
+++ b/engine/src/command/request/builder.rs
@@ -1,0 +1,327 @@
+use super::Request;
+use crate::{
+    command::CommandId,
+    state::{KeyType, Value},
+};
+use alloc::vec::Vec;
+use core::fmt::{Display, Formatter, Result as FmtResult};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RequestBuilderError {
+    ArgumentEmpty,
+    TooManyArguments,
+    ValueEmpty,
+}
+
+impl Display for RequestBuilderError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::ArgumentEmpty => f.write_str("the provided argument is empty"),
+            Self::TooManyArguments => {
+                f.write_str("too many arguments have been given to the builder")
+            }
+            Self::ValueEmpty => f.write_str("the provided value variant is empty (0 length)"),
+        }
+    }
+}
+
+/// Builder to construct valid requests.
+///
+/// The builder is useful because it will ensure that empty arguments are not
+/// provided and that not too many arguments are given.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RequestBuilder {
+    arguments: Option<Vec<Vec<u8>>>,
+    cmd_id: CommandId,
+    key_type: Option<KeyType>,
+}
+
+impl RequestBuilder {
+    /// Create a new request builder.
+    pub fn new(cmd_id: CommandId) -> Self {
+        Self {
+            arguments: None,
+            cmd_id,
+            key_type: None,
+        }
+    }
+
+    /// Consume the builder and return the request serialised as bytes.
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.into_request().into_bytes()
+    }
+
+    /// Consume the builder and return the built request.
+    pub fn into_request(self) -> Request {
+        Request {
+            args: self.arguments,
+            key_type: self.key_type,
+            kind: self.cmd_id,
+        }
+    }
+
+    /// Retrieve an immutable reference to the command ID.
+    pub fn command_id_ref(&self) -> &CommandId {
+        &self.cmd_id
+    }
+
+    /// Set the key type.
+    pub fn key_type(&mut self, key_type: KeyType) -> &mut Self {
+        self.key_type.replace(key_type);
+
+        self
+    }
+
+    /// Retrieve an immutable reference to the key type, if any.
+    pub fn key_type_ref(&self) -> Option<&KeyType> {
+        self.key_type.as_ref()
+    }
+
+    /// Add an argument containing the given bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RequestBuilderError::ArgumentEmpty`] if the given value is
+    /// empty.
+    ///
+    /// Returns [`RequestBuilderError::TooManyArguments`] if the argument would
+    /// not fit in the arguments list.
+    ///
+    /// [`RequestBuilderError::ArgumentEmpty`]: enum.RequestBuilderError.html#variant.ArgumentEmpty
+    /// [`RequestBuilderError::TooManyArguments`]: enum.RequestBuilderError.html#variant.TooManyArguments
+    pub fn bytes(&mut self, bytes: impl Into<Vec<u8>>) -> Result<&mut Self, RequestBuilderError> {
+        self._bytes(bytes.into())
+    }
+
+    fn _bytes(&mut self, bytes: Vec<u8>) -> Result<&mut Self, RequestBuilderError> {
+        if bytes.is_empty() {
+            return Err(RequestBuilderError::ArgumentEmpty);
+        }
+
+        self.push_argument(bytes)?;
+
+        Ok(self)
+    }
+
+    /// Add a value's serialised representation to the arguments.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RequestBuilderError::ArgumentEmpty`] if the given value is
+    /// empty.
+    ///
+    /// Returns [`RequestBuilderError::TooManyArguments`] if the argument would
+    /// not fit in the arguments list.
+    ///
+    /// Returns [`RequestBuilderError::ValueEmpty`] if the given value's
+    /// bytes, list, map, set, or string variant is empty.
+    ///
+    /// [`RequestBuilderError::ArgumentEmpty`]: enum.RequestBuilderError.html#variant.ArgumentEmpty
+    /// [`RequestBuilderError::TooManyArguments`]: enum.RequestBuilderError.html#variant.TooManyArguments
+    /// [`RequestBuilderError::ValueEmpty`]: enum.RequestBuilderError.html#variant.ValueEmpty
+    pub fn value(&mut self, value: impl Into<Value>) -> Result<&mut Self, RequestBuilderError> {
+        self._value(value.into())
+    }
+
+    fn _value(&mut self, value: Value) -> Result<&mut Self, RequestBuilderError> {
+        match value {
+            Value::Boolean(bool) => {
+                let mut buf = Vec::with_capacity(1);
+                buf.push(bool as u8);
+
+                self.push_argument(buf)?;
+            }
+            Value::Bytes(bytes) => {
+                if bytes.is_empty() {
+                    return Err(RequestBuilderError::ValueEmpty);
+                }
+
+                self.push_argument(bytes)?;
+            }
+            Value::Float(float) => self.push_argument(float.to_be_bytes().to_vec())?,
+            Value::Integer(int) => self.push_argument(int.to_be_bytes().to_vec())?,
+            Value::List(list) => {
+                if self.arguments_would_overfill(list.len()) {
+                    return Err(RequestBuilderError::TooManyArguments);
+                }
+
+                for item in list {
+                    if item.is_empty() {
+                        return Err(RequestBuilderError::ValueEmpty);
+                    }
+
+                    self.push_argument(item)?;
+                }
+            }
+            Value::Map(map) => {
+                if self.arguments_would_overfill(map.len()) {
+                    return Err(RequestBuilderError::TooManyArguments);
+                }
+
+                if map.is_empty() {
+                    return Err(RequestBuilderError::ValueEmpty);
+                }
+
+                for (k, v) in map.into_iter() {
+                    self.push_argument(k)?;
+                    self.push_argument(v)?;
+                }
+            }
+            Value::Set(set) => {
+                if self.arguments_would_overfill(set.len()) {
+                    return Err(RequestBuilderError::TooManyArguments);
+                }
+
+                if set.is_empty() {
+                    return Err(RequestBuilderError::ValueEmpty);
+                }
+
+                for item in set {
+                    self.push_argument(item)?;
+                }
+            }
+            Value::String(string) => {
+                if string.is_empty() {
+                    return Err(RequestBuilderError::ValueEmpty);
+                }
+
+                self.push_argument(string.into_bytes())?;
+            }
+        }
+
+        Ok(self)
+    }
+
+    /// Retrieve an immutable reference to an argument.
+    pub fn argument_ref(&self, idx: usize) -> Option<&[u8]> {
+        let arg = self.arguments.as_ref()?.get(idx)?;
+
+        Some(arg.as_slice())
+    }
+
+    fn arguments_would_overfill(&self, len: usize) -> bool {
+        match self.arguments.as_ref() {
+            Some(arguments) => arguments.len() + len > 255,
+            None => len > 255,
+        }
+    }
+
+    /// Pushes an argument to the list.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RequestBuilderError::TooManyArguments`] if the list of
+    /// arguments is already full.
+    ///
+    /// [`RequestBuilderError::TooManyArguments`]: enum.RequestBuilderError.html#variant.TooManyArguments
+    fn push_argument(&mut self, argument: Vec<u8>) -> Result<(), RequestBuilderError> {
+        if let Some(arguments) = self.arguments.as_mut() {
+            if arguments.len() >= 255 {
+                return Err(RequestBuilderError::TooManyArguments);
+            }
+
+            arguments.push(argument);
+        } else {
+            let mut arguments = Vec::new();
+            arguments.push(argument);
+
+            self.arguments.replace(arguments);
+        }
+
+        Ok(())
+    }
+}
+
+impl From<Request> for RequestBuilder {
+    fn from(request: Request) -> Self {
+        let mut builder = Self::new(request.kind);
+
+        if let Some(key_type) = request.key_type {
+            builder.key_type(key_type);
+        }
+
+        if let Some(args) = request.args {
+            builder.arguments.replace(args);
+        }
+
+        builder
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RequestBuilder;
+    use crate::{
+        command::{CommandId, Request},
+        state::{KeyType, Value},
+    };
+
+    #[test]
+    fn test_cmd_id() {
+        let builder = RequestBuilder::new(CommandId::Stats);
+
+        assert_eq!(
+            builder.into_request(),
+            Request {
+                args: None,
+                kind: CommandId::Stats,
+                key_type: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_key_type() {
+        let mut builder = RequestBuilder::new(CommandId::Decrement);
+        builder.key_type(KeyType::Integer);
+
+        assert_eq!(
+            builder.into_request(),
+            Request {
+                args: None,
+                kind: CommandId::Decrement,
+                key_type: Some(KeyType::Integer),
+            }
+        );
+    }
+
+    #[test]
+    fn test_arg_bytes() {
+        let mut builder = RequestBuilder::new(CommandId::Append);
+        builder.key_type(KeyType::List);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+
+        let mut expected_args = Vec::new();
+        expected_args.push(b"foo".to_vec());
+
+        assert_eq!(
+            builder.into_request(),
+            Request {
+                args: Some(expected_args),
+                kind: CommandId::Append,
+                key_type: Some(KeyType::List),
+            }
+        );
+    }
+
+    #[test]
+    fn test_arg_value() {
+        let mut builder = RequestBuilder::new(CommandId::Set);
+        builder.key_type(KeyType::String);
+        assert!(builder.bytes(b"foo".as_ref()).is_ok());
+        assert!(builder.value(Value::Integer(123)).is_ok());
+
+        let mut expected_args = Vec::new();
+        expected_args.push(b"foo".to_vec());
+        expected_args.push(123i64.to_be_bytes().to_vec());
+
+        assert_eq!(
+            builder.into_request(),
+            Request {
+                args: Some(expected_args),
+                kind: CommandId::Set,
+                key_type: Some(KeyType::String),
+            }
+        );
+    }
+}


### PR DESCRIPTION
Add a RequestBuilder struct for constructing requests. This is useful
because it simplifies code that constructs requests - specifically the
arguments of requests - and ensures that not too many arguments or any
empty arguments are in a request.

The `Request::new` and `Request::new_with_type` methods have been
removed in favour of the builder.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>