### PR TITLE
engine: rename to use command_id terminology

### DIFF
--- a/cli/lib/src/parse.rs
+++ b/cli/lib/src/parse.rs
@@ -246,7 +246,7 @@ mod tests {
     #[test]
     fn test_command_is_int() {
         let req = super::parse("is:int foo bar").unwrap();
-        assert_eq!(CommandId::Is, req.kind());
+        assert_eq!(CommandId::Is, req.command_id());
         assert_eq!(Some(KeyType::Integer), req.key_type());
         assert_eq!(Some(b"foo".as_ref()), req.arg(0));
         assert_eq!(Some(b"bar".as_ref()), req.arg(1));
@@ -289,15 +289,15 @@ mod tests {
     #[test]
     fn test_parse() {
         let req = super::parse("echo").unwrap();
-        assert_eq!(CommandId::Echo, req.kind());
+        assert_eq!(CommandId::Echo, req.command_id());
         assert!(req.args(..).is_none());
 
         let req = super::parse("increment:int").unwrap();
-        assert_eq!(CommandId::Increment, req.kind());
+        assert_eq!(CommandId::Increment, req.command_id());
         assert_eq!(Some(KeyType::Integer), req.key_type());
 
         let req = super::parse("increment:by:int foo 3").unwrap();
-        assert_eq!(CommandId::IncrementBy, req.kind());
+        assert_eq!(CommandId::IncrementBy, req.command_id());
         assert_eq!(Some(KeyType::Integer), req.key_type());
         assert!(req.args(..).is_some());
         assert_eq!(2, req.arg_count());

--- a/cli/lib/src/process.rs
+++ b/cli/lib/src/process.rs
@@ -197,7 +197,7 @@ async fn process_inner<B: Backend + Send + Sync + 'static>(
 where
     B::Error: Error,
 {
-    match req.kind() {
+    match req.command_id() {
         CommandId::Decrement => {
             let key = req.key().ok_or_else(|| InnerProcessError::KeyUnspecified)?;
 

--- a/engine/src/command/request/context.rs
+++ b/engine/src/command/request/context.rs
@@ -73,9 +73,10 @@ impl Context {
 
                 match self.stage {
                     Stage::Init => self.stage_init(buf)?,
-                    Stage::Kind { command_id, key_type } => {
-                        self.stage_kind(buf, key_type, command_id)?
-                    }
+                    Stage::Kind {
+                        command_id,
+                        key_type,
+                    } => self.stage_kind(buf, key_type, command_id)?,
                     Stage::ArgumentParsing {
                         argument_count,
                         command_id,
@@ -128,7 +129,10 @@ impl Context {
             return Ok(Conclusion::Finished((command_id, None)));
         }
 
-        self.stage = Stage::Kind { command_id, key_type };
+        self.stage = Stage::Kind {
+            command_id,
+            key_type,
+        };
         self.idx = self.idx.wrapping_add(1);
 
         Ok(Conclusion::Next)

--- a/engine/src/command/request/context.rs
+++ b/engine/src/command/request/context.rs
@@ -4,7 +4,7 @@ use alloc::borrow::Cow;
 use arrayvec::ArrayVec;
 use core::convert::{TryFrom, TryInto};
 
-type Conclusion<'a> = ContextConclusion<(Option<KeyType>, CommandId)>;
+type Conclusion<'a> = ContextConclusion<(CommandId, Option<KeyType>)>;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[repr(u8)]
@@ -29,12 +29,12 @@ impl TryFrom<u8> for ParseError {
 enum Stage {
     Init,
     Kind {
-        cmd_type: CommandId,
+        command_id: CommandId,
         key_type: Option<KeyType>,
     },
     ArgumentParsing {
         argument_count: u8,
-        cmd_type: CommandId,
+        command_id: CommandId,
         key_type: Option<KeyType>,
     },
 }
@@ -73,25 +73,25 @@ impl Context {
 
                 match self.stage {
                     Stage::Init => self.stage_init(buf)?,
-                    Stage::Kind { cmd_type, key_type } => {
-                        self.stage_kind(buf, key_type, cmd_type)?
+                    Stage::Kind { command_id, key_type } => {
+                        self.stage_kind(buf, key_type, command_id)?
                     }
                     Stage::ArgumentParsing {
                         argument_count,
-                        cmd_type,
+                        command_id,
                         key_type,
-                    } => self.stage_argument_parsing(buf, cmd_type, key_type, argument_count)?,
+                    } => self.stage_argument_parsing(buf, command_id, key_type, argument_count)?,
                 }
             };
 
             match conclusion {
-                Conclusion::Finished((key_type, kind)) => {
+                Conclusion::Finished((command_id, key_type)) => {
                     self.reset();
 
                     return Ok(Some(Request {
                         buf: Cow::Borrowed(buf),
+                        command_id,
                         key_type,
-                        kind,
                         positions: Cow::Borrowed(&self.positions),
                     }));
                 }
@@ -120,15 +120,15 @@ impl Context {
             None
         };
 
-        let cmd_type = CommandId::try_from(byte).map_err(|_| ParseError::CommandIdInvalid)?;
+        let command_id = CommandId::try_from(byte).map_err(|_| ParseError::CommandIdInvalid)?;
 
         // If the command type is simple and has no arguments or keys, then
         // we can just return a successful command here.
-        if cmd_type.is_simple() {
-            return Ok(Conclusion::Finished((None, cmd_type)));
+        if command_id.is_simple() {
+            return Ok(Conclusion::Finished((command_id, None)));
         }
 
-        self.stage = Stage::Kind { cmd_type, key_type };
+        self.stage = Stage::Kind { command_id, key_type };
         self.idx = self.idx.wrapping_add(1);
 
         Ok(Conclusion::Next)
@@ -138,7 +138,7 @@ impl Context {
         &mut self,
         buf: &[u8],
         key_type: Option<KeyType>,
-        cmd_type: CommandId,
+        command_id: CommandId,
     ) -> Result<Conclusion, ParseError> {
         let argument_count = match buf.get(self.idx) {
             Some(argument_count) => *argument_count,
@@ -147,7 +147,7 @@ impl Context {
 
         self.stage = Stage::ArgumentParsing {
             argument_count,
-            cmd_type,
+            command_id,
             key_type,
         };
         self.idx = self.idx.saturating_add(1);
@@ -158,7 +158,7 @@ impl Context {
     fn stage_argument_parsing<'a>(
         &'a mut self,
         buf: &'a [u8],
-        cmd_type: CommandId,
+        command_id: CommandId,
         key_type: Option<KeyType>,
         argument_count: u8,
     ) -> Result<Conclusion, ParseError> {
@@ -178,7 +178,7 @@ impl Context {
         self.idx += 4 + arg_len;
 
         if self.positions.len() == argument_count as usize {
-            Ok(Conclusion::Finished((key_type, cmd_type)))
+            Ok(Conclusion::Finished((command_id, key_type)))
         } else {
             Ok(Conclusion::Next)
         }
@@ -252,7 +252,7 @@ mod tests {
             .expect("parses correctly")
             .expect("returns a command");
 
-        assert_eq!(cmd.kind, CommandId::Increment);
+        assert_eq!(cmd.command_id, CommandId::Increment);
 
         Ok(())
     }

--- a/engine/src/command/request/mod.rs
+++ b/engine/src/command/request/mod.rs
@@ -123,12 +123,16 @@ impl<'a> Iterator for Arguments<'a> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Request<'a> {
     buf: Cow<'a, [u8]>,
+    command_id: CommandId,
     key_type: Option<KeyType>,
-    kind: CommandId,
     positions: Cow<'a, ArrayVec<[usize; 256]>>,
 }
 
 impl<'a> Request<'a> {
+    pub fn command_id(&self) -> CommandId {
+        self.command_id
+    }
+
     pub fn args(&self, range: impl RangeBounds<usize>) -> Option<Arguments<'_>> {
         if self.arg_count() == 0 {
             return None;
@@ -183,7 +187,7 @@ impl<'a> Request<'a> {
     }
 
     pub fn key(&self) -> Option<&[u8]> {
-        if self.kind.key_notation() == KeyNotation::None {
+        if self.command_id.key_notation() == KeyNotation::None {
             return None;
         }
 
@@ -200,10 +204,6 @@ impl<'a> Request<'a> {
     /// [`Append`]: impl/struct.Append.html
     pub fn key_type(&self) -> Option<KeyType> {
         self.key_type
-    }
-
-    pub fn kind(&self) -> CommandId {
-        self.kind
     }
 
     // pub fn into_args(mut self) -> Option<Vec<Vec<u8>>> {

--- a/engine/src/hop.rs
+++ b/engine/src/hop.rs
@@ -168,7 +168,7 @@ impl Hop {
     /// Dispatch a request to the engine, providing a response to write the
     /// response to on success.
     pub fn dispatch(&self, req: &Request, res: &mut Vec<u8>) -> DispatchResult<()> {
-        let res = match req.kind() {
+        let res = match req.command_id() {
             CommandId::Append => Append::dispatch(self, req, res),
             CommandId::DecrementBy => DecrementBy::dispatch(self, req, res),
             CommandId::Decrement => Decrement::dispatch(self, req, res),


### PR DESCRIPTION
Rename the fields and methods of structs to use the 'command_id'
terminology over the 'cmd_type' or 'kind' terminology. This is clearer,
more concise, and consistent.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>