### PR TITLE
server: use async main macro

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.1.0"
 env_logger = { default-features = false, version = "^0.7.0" }
 log = { default-features = false, version = "^0.4.8" }
 hop-engine = { default-features = false, path = "../engine" }
-tokio = { default-features = false, features = ["blocking", "io-util", "net", "rt-threaded", "stream"], version = "^0.2.20" }
+tokio = { default-features = false, features = ["blocking", "io-util", "macros", "net", "rt-threaded", "stream"], version = "^0.2.20" }
 
 [dev-dependencies]
 rusty-hook = { default-features = false, version = "^0.11.0" }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -16,7 +16,6 @@ use std::{
 use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
     net::{TcpListener, TcpStream},
-    runtime::Builder as RuntimeBuilder,
     stream::StreamExt,
     task,
 };
@@ -44,15 +43,10 @@ impl Config {
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
-    let mut runtime = RuntimeBuilder::new().threaded_scheduler().build()?;
-
-    runtime.block_on(run())
-}
-
-async fn run() -> Result<(), Box<dyn Error>> {
     let config = Config::new();
 
     debug!("Binding socket");


### PR DESCRIPTION
Use a `#[tokio::main]` macro on the main function, so that we don't have
to build a runtime ourselves. This simplifies code and doesn't have too
much of a compile-time cost.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>