### PR TITLE
client: add no_std support

### DIFF
--- a/cli/lib/Cargo.toml
+++ b/cli/lib/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/hopdb/hop.git"
 version = "0.1.0"
 
 [dependencies]
-hop = { default-features = false, path = "../../client" }
+hop = { default-features = false, features = ["std"], path = "../../client" }
 hop-engine = { default-features = false, path = "../../engine" }
 
 [lib]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -17,8 +17,12 @@ dashmap = { default-features = false, version = "^3.11.1" }
 hop-engine = { default-features = false, path = "../engine" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { default-features = false, features = ["io-util", "net", "sync"], version = "^0.2.20" }
+tokio = { default-features = false, features = ["io-util", "net", "sync"], optional = true, version = "^0.2.20" }
 
 [dev-dependencies]
 static_assertions = { default-features = false, version = "^1.1.0" }
 tokio = { default-features = false, features = ["io-util", "macros", "net", "sync"], version = "^0.2.20" }
+
+[features]
+default = ["std", "tokio"]
+std = []

--- a/client/src/backend/memory.rs
+++ b/client/src/backend/memory.rs
@@ -1,6 +1,11 @@
 use super::Backend;
 use crate::model::StatsData;
+use alloc::{boxed::Box, vec::Vec};
 use async_trait::async_trait;
+use core::{
+    convert::TryInto,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
 use hop_engine::{
     command::{
         request::{ParseError as RequestParseError, RequestBuilder, RequestBuilderError},
@@ -9,11 +14,6 @@ use hop_engine::{
     },
     state::{KeyType, Value},
     Hop,
-};
-use std::{
-    convert::TryInto,
-    error::Error as StdError,
-    fmt::{Display, Formatter, Result as FmtResult},
 };
 
 #[derive(Debug)]
@@ -51,15 +51,21 @@ impl Display for Error {
     }
 }
 
-impl StdError for Error {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        match self {
-            Self::BadRequest { .. } => None,
-            Self::BuildingRequest { .. } => None,
-            Self::Dispatching { .. } => None,
-            Self::KeyTypeInvalid { .. } => None,
-            Self::KeyTypeUnsupported { .. } => None,
-            Self::RunningCommand { .. } => None,
+#[cfg(all(not(no_std), feature = "std"))]
+mod if_std {
+    use super::Error;
+    use std::error::Error as StdError;
+
+    impl StdError for Error {
+        fn source(&self) -> Option<&(dyn StdError + 'static)> {
+            match self {
+                Self::BadRequest { .. } => None,
+                Self::BuildingRequest { .. } => None,
+                Self::Dispatching { .. } => None,
+                Self::KeyTypeInvalid { .. } => None,
+                Self::KeyTypeUnsupported { .. } => None,
+                Self::RunningCommand { .. } => None,
+            }
         }
     }
 }

--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -1,14 +1,15 @@
 pub mod memory;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "tokio"))]
 pub mod server;
 
 pub use self::memory::MemoryBackend;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "tokio"))]
 pub use self::server::ServerBackend;
 
 use crate::model::StatsData;
+use alloc::{boxed::Box, vec::Vec};
 use async_trait::async_trait;
 use hop_engine::state::{KeyType, Value};
 

--- a/client/src/backend/server.rs
+++ b/client/src/backend/server.rs
@@ -1,6 +1,12 @@
 use super::Backend;
 use crate::model::StatsData;
+use alloc::{boxed::Box, vec::Vec};
 use async_trait::async_trait;
+use core::{
+    convert::TryInto,
+    fmt::{Display, Formatter, Result as FmtResult},
+    result::Result as StdResult,
+};
 use hop_engine::{
     command::{
         request::{ParseError, Request, RequestBuilder, RequestBuilderError},
@@ -9,13 +15,7 @@ use hop_engine::{
     },
     state::{KeyType, Value},
 };
-use std::{
-    convert::TryInto,
-    error::Error as StdError,
-    fmt::{Display, Formatter, Result as FmtResult},
-    io::Error as IoError,
-    result::Result as StdResult,
-};
+use std::{error::Error as StdError, io::Error as IoError};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt, BufReader},
     net::{
@@ -402,8 +402,8 @@ impl Backend for ServerBackend {
 #[cfg(test)]
 mod tests {
     use super::{Error, ServerBackend};
+    use core::fmt::Debug;
     use static_assertions::assert_impl_all;
-    use std::fmt::Debug;
 
     assert_impl_all!(Error: Debug, Send, Sync);
     assert_impl_all!(ServerBackend: Debug, Send, Sync);

--- a/client/src/model.rs
+++ b/client/src/model.rs
@@ -1,13 +1,15 @@
+use alloc::vec::Vec;
+use core::convert::TryInto;
+use dashmap::DashMap;
 use hop_engine::metrics::Metric;
-use std::{collections::HashMap, convert::TryInto};
 
 #[derive(Clone, Debug)]
 pub struct StatsData {
-    inner: HashMap<Vec<u8>, Vec<u8>>,
+    inner: DashMap<Vec<u8>, Vec<u8>>,
 }
 
 impl StatsData {
-    pub(crate) fn new(map: HashMap<Vec<u8>, Vec<u8>>) -> Self {
+    pub(crate) fn new(map: DashMap<Vec<u8>, Vec<u8>>) -> Self {
         Self { inner: map }
     }
 
@@ -39,8 +41,8 @@ impl StatsData {
 #[cfg(test)]
 mod tests {
     use super::StatsData;
+    use core::fmt::Debug;
     use static_assertions::assert_impl_all;
-    use std::fmt::Debug;
 
     assert_impl_all!(StatsData: Clone, Debug);
 }

--- a/client/src/request/append/append_bytes.rs
+++ b/client/src/request/append/append_bytes.rs
@@ -1,12 +1,12 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A configured `set` command that will resolve to bytes when `await`ed.
 ///
@@ -61,6 +61,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::AppendBytes;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(AppendBytes<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/append/append_list.rs
+++ b/client/src/request/append/append_list.rs
@@ -1,12 +1,12 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A configured `set` command that will resolve to bytes when `await`ed.
 ///
@@ -61,6 +61,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::AppendList;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(AppendList<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/append/append_string.rs
+++ b/client/src/request/append/append_string.rs
@@ -1,12 +1,12 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, string::String, sync::Arc};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A configured `set` command that will resolve to bytes when `await`ed.
 ///
@@ -61,6 +61,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::AppendString;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(AppendString<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/append/mod.rs
+++ b/client/src/request/append/mod.rs
@@ -5,7 +5,7 @@ mod append_string;
 pub use self::{append_bytes::AppendBytes, append_list::AppendList, append_string::AppendString};
 
 use crate::Backend;
-use std::sync::Arc;
+use alloc::{string::String, sync::Arc, vec::Vec};
 
 /// A request to append to a key.
 pub struct AppendUnconfigured<B: Backend, K: AsRef<[u8]> + Send + Unpin> {
@@ -65,6 +65,7 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> AppendUnconfigured<B, K
 mod tests {
     use super::AppendUnconfigured;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(AppendUnconfigured<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/decrement/decrement_float.rs
+++ b/client/src/request/decrement/decrement_float.rs
@@ -1,12 +1,12 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A configured `get` command that will resolve to a float when `await`ed.
 ///
@@ -67,6 +67,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::DecrementFloat;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(DecrementFloat<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/decrement/decrement_int.rs
+++ b/client/src/request/decrement/decrement_int.rs
@@ -1,12 +1,12 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A configured `get` command that will resolve to a float when `await`ed.
 ///
@@ -67,6 +67,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::DecrementInteger;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(DecrementInteger<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/decrement/mod.rs
+++ b/client/src/request/decrement/mod.rs
@@ -5,13 +5,13 @@ pub use self::{decrement_float::DecrementFloat, decrement_int::DecrementInteger}
 
 use super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 pub struct Decrement<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
@@ -61,6 +61,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::Decrement;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(Decrement<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/delete.rs
+++ b/client/src/request/delete.rs
@@ -1,9 +1,9 @@
 use super::MaybeInFlightFuture;
 use crate::Backend;
-use std::{
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
 
@@ -47,6 +47,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::Delete;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(Delete<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/echo.rs
+++ b/client/src/request/echo.rs
@@ -1,9 +1,9 @@
 use super::MaybeInFlightFuture;
 use crate::Backend;
-use std::{
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
 
@@ -47,6 +47,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::Echo;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(Echo<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/exists.rs
+++ b/client/src/request/exists.rs
@@ -1,11 +1,11 @@
 use super::{CommandConfigurationError, MaybeInFlightFuture};
 use crate::Backend;
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
-use std::sync::Arc;
 
 /// Request to determine whether one or more keys exist.
 ///
@@ -133,6 +133,7 @@ impl<'a, B: Backend + Send + 'static, K: AsRef<[u8]> + 'a + Send + Unpin> Future
 mod tests {
     use super::{Exists, ExistsConfigured};
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(Exists<MemoryBackend>: Send);

--- a/client/src/request/get/get_boolean.rs
+++ b/client/src/request/get/get_boolean.rs
@@ -1,12 +1,12 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A configured `get` command that will resolve to a boolean when `await`ed.
 ///
@@ -58,6 +58,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::GetBoolean;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(GetBoolean<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/get/get_bytes.rs
+++ b/client/src/request/get/get_bytes.rs
@@ -1,12 +1,12 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A configured `get` command that will resolve to bytes when `await`ed.
 ///
@@ -58,6 +58,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::GetBytes;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(GetBytes<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/get/get_float.rs
+++ b/client/src/request/get/get_float.rs
@@ -1,12 +1,12 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A configured `get` command that will resolve to a float when `await`ed.
 ///
@@ -58,6 +58,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::GetFloat;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(GetFloat<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/get/get_integer.rs
+++ b/client/src/request/get/get_integer.rs
@@ -1,12 +1,12 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A configured `get` command that will resolve to an integer when `await`ed.
 ///
@@ -58,6 +58,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::GetInteger;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(GetInteger<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/get/get_list.rs
+++ b/client/src/request/get/get_list.rs
@@ -1,12 +1,12 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A configured `get` command that will resolve to a list when `await`ed.
 ///
@@ -58,6 +58,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::GetList;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(GetList<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/get/get_map.rs
+++ b/client/src/request/get/get_map.rs
@@ -1,13 +1,13 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use dashmap::DashMap;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use dashmap::DashMap;
+use hop_engine::state::Value;
 
 /// A configured `get` command that will resolve to a map when `await`ed.
 ///
@@ -59,6 +59,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::GetMap;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(GetMap<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/get/get_set.rs
+++ b/client/src/request/get/get_set.rs
@@ -1,13 +1,13 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use dashmap::DashSet;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use dashmap::DashSet;
+use hop_engine::state::Value;
 
 /// A configured `get` command that will resolve to a set when `await`ed.
 ///
@@ -59,6 +59,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::GetSet;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(GetSet<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/get/get_string.rs
+++ b/client/src/request/get/get_string.rs
@@ -1,12 +1,12 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, string::String, sync::Arc};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A configured `get` command that will resolve to a string when `await`ed.
 ///
@@ -58,6 +58,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::GetString;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(GetString<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/get/mod.rs
+++ b/client/src/request/get/mod.rs
@@ -14,13 +14,13 @@ pub use self::{
 
 use super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A Get request that hasn't been configured with a type of value to get.
 ///
@@ -293,6 +293,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin + 'a>
 mod tests {
     use super::GetUnconfigured;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(GetUnconfigured<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/increment/increment_float.rs
+++ b/client/src/request/increment/increment_float.rs
@@ -1,12 +1,12 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A configured `get` command that will resolve to a float when `await`ed.
 ///
@@ -67,6 +67,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::IncrementFloat;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(IncrementFloat<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/increment/increment_int.rs
+++ b/client/src/request/increment/increment_int.rs
@@ -1,12 +1,12 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A configured `get` command that will resolve to a float when `await`ed.
 ///
@@ -67,6 +67,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::IncrementInteger;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(IncrementInteger<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/increment/mod.rs
+++ b/client/src/request/increment/mod.rs
@@ -5,13 +5,13 @@ pub use self::{increment_float::IncrementFloat, increment_int::IncrementInteger}
 
 use super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::{KeyType, Value};
-use std::{
+use alloc::{boxed::Box, sync::Arc};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::{KeyType, Value};
 
 pub struct Increment<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
@@ -65,6 +65,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::Increment;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(Increment<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/is.rs
+++ b/client/src/request/is.rs
@@ -1,12 +1,12 @@
 use super::{CommandConfigurationError, MaybeInFlightFuture};
 use crate::Backend;
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
 use hop_engine::state::KeyType;
-use std::sync::Arc;
 
 /// Request to determine whether one or more keys exist.
 ///
@@ -138,6 +138,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + 'a + Send + Unpin>
 mod tests {
     use super::{Is, IsConfigured};
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(Is<MemoryBackend>: Send);

--- a/client/src/request/keys.rs
+++ b/client/src/request/keys.rs
@@ -1,9 +1,9 @@
 use super::MaybeInFlightFuture;
 use crate::Backend;
-use std::{
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
 
@@ -47,6 +47,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::Keys;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(Keys<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/length.rs
+++ b/client/src/request/length.rs
@@ -1,12 +1,12 @@
 use super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::KeyType;
-use std::{
+use alloc::{boxed::Box, sync::Arc};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::KeyType;
 
 /// Request to retrieve the length of a key, optionally only if it is of a
 /// certain type.
@@ -81,6 +81,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::Length;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(Length<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/mod.rs
+++ b/client/src/request/mod.rs
@@ -28,12 +28,12 @@ pub use self::{
     stats::Stats,
 };
 
+use alloc::boxed::Box;
 use core::{
     fmt::{Display, Formatter, Result as FmtResult},
     future::Future,
     pin::Pin,
 };
-use std::error::Error;
 
 type MaybeInFlightFuture<'a, Ok, Err> =
     Option<Pin<Box<dyn Future<Output = Result<Ok, Err>> + Send + 'a>>>;
@@ -53,13 +53,14 @@ impl Display for CommandConfigurationError {
     }
 }
 
-impl Error for CommandConfigurationError {}
+#[cfg(feature = "std")]
+impl std::error::Error for CommandConfigurationError {}
 
 #[cfg(test)]
 mod tests {
     use super::CommandConfigurationError;
+    use core::fmt::Debug;
     use static_assertions::assert_impl_all;
-    use std::fmt::Debug;
 
     assert_impl_all!(CommandConfigurationError: Clone, Debug, Send);
 }

--- a/client/src/request/rename.rs
+++ b/client/src/request/rename.rs
@@ -1,9 +1,9 @@
 use super::MaybeInFlightFuture;
 use crate::Backend;
-use std::{
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
 
@@ -63,6 +63,7 @@ impl<
 mod tests {
     use super::Rename;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(Rename<MemoryBackend, Vec<u8>, Vec<u8>>: Send);

--- a/client/src/request/set/mod.rs
+++ b/client/src/request/set/mod.rs
@@ -15,8 +15,9 @@ pub use self::{
 };
 
 use crate::Backend;
+use alloc::{string::String, sync::Arc, vec::Vec};
+use core::iter::FromIterator;
 use hop_engine::state::Value;
-use std::{iter::FromIterator, sync::Arc};
 
 /// An Set request that hasn't been configured with a value to set.
 ///
@@ -283,6 +284,7 @@ impl<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> SetUnconfigured<B, K> {
 mod tests {
     use super::SetUnconfigured;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(SetUnconfigured<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/set/set_boolean.rs
+++ b/client/src/request/set/set_boolean.rs
@@ -1,12 +1,12 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A configured `set` command that will resolve to a boolean when `await`ed.
 ///
@@ -61,6 +61,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::SetBoolean;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(SetBoolean<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/set/set_bytes.rs
+++ b/client/src/request/set/set_bytes.rs
@@ -1,12 +1,12 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A configured `set` command that will resolve to bytes when `await`ed.
 ///
@@ -61,6 +61,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::SetBytes;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(SetBytes<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/set/set_float.rs
+++ b/client/src/request/set/set_float.rs
@@ -1,12 +1,12 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A configured `set` command that will resolve to a float when `await`ed.
 ///
@@ -61,6 +61,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::SetFloat;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(SetFloat<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/set/set_integer.rs
+++ b/client/src/request/set/set_integer.rs
@@ -1,12 +1,12 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A configured `set` command that will resolve to an integer when `await`ed.
 ///
@@ -61,6 +61,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::SetInteger;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(SetInteger<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/set/set_list.rs
+++ b/client/src/request/set/set_list.rs
@@ -1,12 +1,12 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A configured `set` command that will resolve to a list when `await`ed.
 ///
@@ -61,6 +61,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::SetList;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(SetList<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/set/set_map.rs
+++ b/client/src/request/set/set_map.rs
@@ -1,13 +1,13 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use dashmap::DashMap;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use dashmap::DashMap;
+use hop_engine::state::Value;
 
 /// A configured `set` command that will resolve to a map when `await`ed.
 ///
@@ -62,6 +62,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::SetMap;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(SetMap<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/set/set_set.rs
+++ b/client/src/request/set/set_set.rs
@@ -1,13 +1,13 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use core::{
     future::Future,
     iter::FromIterator,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A configured `set` command that will resolve to a set when `await`ed.
 ///
@@ -64,6 +64,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::SetSet;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(SetSet<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/set/set_string.rs
+++ b/client/src/request/set/set_string.rs
@@ -1,12 +1,12 @@
 use super::super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, string::String, sync::Arc};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A configured `set` command that will resolve to a string when `await`ed.
 ///
@@ -61,6 +61,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::SetString;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(SetString<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/set/set_value.rs
+++ b/client/src/request/set/set_value.rs
@@ -1,12 +1,13 @@
 use super::super::MaybeInFlightFuture;
+
 use crate::Backend;
-use hop_engine::state::Value;
-use std::{
+use alloc::{boxed::Box, sync::Arc};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::Value;
 
 /// A configured `set` command that will resolve to a generic engine value when
 /// `await`ed.
@@ -57,6 +58,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::SetValue;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(SetValue<MemoryBackend, Vec<u8>>: Send);

--- a/client/src/request/stats.rs
+++ b/client/src/request/stats.rs
@@ -1,9 +1,9 @@
 use super::MaybeInFlightFuture;
 use crate::{model::StatsData, Backend};
-use std::{
+use alloc::{boxed::Box, sync::Arc};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
 

--- a/client/src/request/type.rs
+++ b/client/src/request/type.rs
@@ -1,12 +1,12 @@
 use super::MaybeInFlightFuture;
 use crate::Backend;
-use hop_engine::state::KeyType;
-use std::{
+use alloc::{boxed::Box, sync::Arc};
+use core::{
     future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use hop_engine::state::KeyType;
 
 pub struct Type<'a, B: Backend, K: AsRef<[u8]> + 'a + Send + Unpin> {
     backend: Option<Arc<B>>,
@@ -48,6 +48,7 @@ impl<'a, B: Backend + Send + Sync + 'static, K: AsRef<[u8]> + Send + Unpin> Futu
 mod tests {
     use super::Type;
     use crate::backend::MemoryBackend;
+    use alloc::vec::Vec;
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(Type<MemoryBackend, Vec<u8>>: Send);


### PR DESCRIPTION
Add `no_std` support in the client. There's now one feature, `std`,
which is always available. If this is enabled, then it will add
`std::error::Error` support for errors. If it is disabled, then `no_std`
support will be enabled.

Additionally, there is now a `tokio` feature which enables server
backend support. `tokio` requires the `std` feature to be enabled.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>