### PR TITLE
engine: simplify command impls

### DIFF
--- a/engine/src/command/impl/append.rs
+++ b/engine/src/command/impl/append.rs
@@ -1,4 +1,6 @@
-use super::super::{response, Dispatch, DispatchError, DispatchResult, Request};
+use super::super::{
+    request::Arguments, response, Dispatch, DispatchError, DispatchResult, Request,
+};
 use crate::{
     state::{KeyType, Value},
     Hop,
@@ -9,45 +11,62 @@ use core::str;
 
 pub struct Append;
 
+impl Append {
+    fn bytes(hop: &Hop, args: Arguments<'_>, resp: &mut Vec<u8>, key: &[u8]) -> DispatchResult<()> {
+        let mut key = hop.state().key_or_insert_with(key, Value::bytes);
+        let bytes = key.as_bytes_mut().ok_or(DispatchError::KeyTypeDifferent)?;
+
+        for arg in args {
+            bytes.extend_from_slice(arg);
+        }
+
+        response::write_bytes(resp, bytes.as_ref());
+
+        Ok(())
+    }
+
+    fn list(hop: &Hop, args: Arguments<'_>, resp: &mut Vec<u8>, key: &[u8]) -> DispatchResult<()> {
+        let mut key = hop.state().key_or_insert_with(key, Value::list);
+        let list = key.as_list_mut().ok_or(DispatchError::KeyTypeDifferent)?;
+
+        list.append(&mut args.map(ToOwned::to_owned).collect());
+
+        response::write_list(resp, list.iter());
+
+        Ok(())
+    }
+
+    fn string(
+        hop: &Hop,
+        args: Arguments<'_>,
+        resp: &mut Vec<u8>,
+        key: &[u8],
+    ) -> DispatchResult<()> {
+        let mut key = hop.state().key_or_insert_with(key, Value::string);
+        let string = key.as_string_mut().ok_or(DispatchError::KeyTypeDifferent)?;
+
+        for arg in args {
+            if let Ok(arg) = str::from_utf8(arg) {
+                string.push_str(arg);
+            }
+        }
+
+        response::write_str(resp, &string);
+
+        Ok(())
+    }
+}
+
 impl Dispatch for Append {
     fn dispatch(hop: &Hop, req: &Request, resp: &mut Vec<u8>) -> DispatchResult<()> {
         let key = req.arg(0).ok_or(DispatchError::KeyUnspecified)?;
         let args = req.args(1..).ok_or(DispatchError::ArgumentRetrieval)?;
 
         match req.key_type() {
-            Some(KeyType::Bytes) | None => {
-                let mut key = hop.state().key_or_insert_with(key, Value::bytes);
-                let bytes = key.as_bytes_mut().ok_or(DispatchError::KeyTypeDifferent)?;
-
-                for arg in args {
-                    bytes.extend_from_slice(arg);
-                }
-
-                response::write_bytes(resp, bytes.as_ref());
-            }
-            Some(KeyType::List) => {
-                let mut key = hop.state().key_or_insert_with(key, Value::list);
-                let list = key.as_list_mut().ok_or(DispatchError::KeyTypeDifferent)?;
-
-                list.append(&mut args.map(ToOwned::to_owned).collect());
-
-                response::write_list(resp, list.iter());
-            }
-            Some(KeyType::String) => {
-                let mut key = hop.state().key_or_insert_with(key, Value::string);
-                let string = key.as_string_mut().ok_or(DispatchError::KeyTypeDifferent)?;
-
-                for arg in args {
-                    if let Ok(arg) = str::from_utf8(arg) {
-                        string.push_str(arg);
-                    }
-                }
-
-                response::write_str(resp, &string);
-            }
-            Some(_) => return Err(DispatchError::KeyTypeDifferent),
+            Some(KeyType::Bytes) | None => Self::bytes(hop, args, resp, key),
+            Some(KeyType::List) => Self::list(hop, args, resp, key),
+            Some(KeyType::String) => Self::string(hop, args, resp, key),
+            Some(_) => Err(DispatchError::KeyTypeDifferent),
         }
-
-        Ok(())
     }
 }

--- a/engine/src/command/impl/decrement.rs
+++ b/engine/src/command/impl/decrement.rs
@@ -1,8 +1,8 @@
 use super::{
     super::{Dispatch, DispatchError, DispatchResult, Request},
-    decrement_by::DecrementBy,
+    increment_by::IncrementBy,
 };
-use crate::Hop;
+use crate::{state::KeyType, Hop};
 use alloc::vec::Vec;
 
 pub struct Decrement;
@@ -11,7 +11,11 @@ impl Dispatch for Decrement {
     fn dispatch(hop: &Hop, req: &Request, resp: &mut Vec<u8>) -> DispatchResult<()> {
         let key = req.key().ok_or(DispatchError::KeyUnspecified)?;
 
-        DecrementBy::decrement(hop, key, resp)
+        if req.key_type() == Some(KeyType::Float) {
+            IncrementBy::increment_float_by(hop, key, -1f64, resp)
+        } else {
+            IncrementBy::increment_int_by(hop, key, -1, resp)
+        }
     }
 }
 

--- a/engine/src/command/impl/delete.rs
+++ b/engine/src/command/impl/delete.rs
@@ -11,9 +11,10 @@ impl Dispatch for Delete {
         }
 
         let key = req.key().ok_or(DispatchError::KeyUnspecified)?;
-        let state = hop.state();
-
-        let (k, _) = state.remove(key).ok_or(DispatchError::PreconditionFailed)?;
+        let (k, _) = hop
+            .state()
+            .remove(key)
+            .ok_or(DispatchError::PreconditionFailed)?;
 
         let response = Response::from(k);
         response.copy_to(resp);

--- a/engine/src/command/impl/exists.rs
+++ b/engine/src/command/impl/exists.rs
@@ -11,9 +11,8 @@ impl Dispatch for Exists {
         }
 
         let mut args = req.args(..).ok_or(DispatchError::ArgumentRetrieval)?;
-        let state = hop.state();
 
-        let all = args.all(|key| state.contains_key(key));
+        let all = args.all(|key| hop.state().contains_key(key));
 
         response::write_bool(resp, all);
 

--- a/engine/src/command/impl/get.rs
+++ b/engine/src/command/impl/get.rs
@@ -9,8 +9,8 @@ pub struct Get;
 impl Dispatch for Get {
     fn dispatch(hop: &Hop, req: &Request, resp: &mut Vec<u8>) -> DispatchResult<()> {
         let key = req.key().ok_or(DispatchError::KeyUnspecified)?;
-        let state = hop.state();
-        let r = state
+        let r = hop
+            .state()
             .key_ref(key)
             .ok_or_else(|| DispatchError::KeyNonexistent)?;
 

--- a/engine/src/command/impl/increment.rs
+++ b/engine/src/command/impl/increment.rs
@@ -2,7 +2,7 @@ use super::{
     super::{Dispatch, DispatchError, DispatchResult, Request},
     increment_by::IncrementBy,
 };
-use crate::Hop;
+use crate::{state::KeyType, Hop};
 use alloc::vec::Vec;
 
 pub struct Increment;
@@ -11,7 +11,11 @@ impl Dispatch for Increment {
     fn dispatch(hop: &Hop, req: &Request, resp: &mut Vec<u8>) -> DispatchResult<()> {
         let key = req.key().ok_or(DispatchError::KeyUnspecified)?;
 
-        IncrementBy::increment(hop, key, resp)
+        if req.key_type() == Some(KeyType::Float) {
+            IncrementBy::increment_float_by(hop, key, 1f64, resp)
+        } else {
+            IncrementBy::increment_int_by(hop, key, 1, resp)
+        }
     }
 }
 

--- a/engine/src/command/impl/increment_by.rs
+++ b/engine/src/command/impl/increment_by.rs
@@ -1,8 +1,5 @@
 use super::super::{response, Dispatch, DispatchError, DispatchResult, Request};
-use crate::{
-    state::{KeyType, Value},
-    Hop,
-};
+use crate::{state::Value, Hop};
 use alloc::vec::Vec;
 
 pub struct IncrementBy;
@@ -40,16 +37,6 @@ impl IncrementBy {
         response::write_int(resp, *int);
 
         Ok(())
-    }
-
-    pub fn increment(hop: &Hop, key: &[u8], resp: &mut Vec<u8>) -> DispatchResult<()> {
-        hop.state().key_or_insert_with(b"foo", Value::integer);
-
-        match hop.state().key_ref(key).map(|r| r.value().kind()) {
-            Some(KeyType::Float) => Self::increment_float_by(hop, key, 1f64, resp),
-            Some(KeyType::Integer) => Self::increment_int_by(hop, key, 1, resp),
-            _ => Err(DispatchError::KeyTypeDifferent),
-        }
     }
 }
 

--- a/engine/src/command/impl/is.rs
+++ b/engine/src/command/impl/is.rs
@@ -10,9 +10,8 @@ impl Dispatch for Is {
             .key_type()
             .ok_or_else(|| DispatchError::KeyTypeRequired)?;
         let mut args = req.args(..).ok_or(DispatchError::ArgumentRetrieval)?;
-        let state = hop.state();
 
-        let all = args.all(|key| match state.key_ref(key) {
+        let all = args.all(|key| match hop.state().key_ref(key) {
             Some(value) => value.value().kind() == key_type,
             None => false,
         });

--- a/engine/src/command/impl/type.rs
+++ b/engine/src/command/impl/type.rs
@@ -19,7 +19,7 @@ impl Dispatch for Type {
             .key_ref(key)
             .ok_or_else(|| DispatchError::KeyNonexistent)?;
 
-        response::write_int(resp, key.kind() as u8 as i64);
+        response::write_int(resp, key.kind() as i64);
 
         Ok(())
     }

--- a/engine/src/hop.rs
+++ b/engine/src/hop.rs
@@ -217,6 +217,7 @@ impl Hop {
     }
 
     /// Return an immutable reference to the state.
+    #[inline]
     pub fn state(&self) -> &State {
         &self.0.state
     }


### PR DESCRIPTION
Simplify command implementations by reducing cyclomatic complexity and
de-duplicating code.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>