### PR TITLE
engine: add state::key_type method

### DIFF
--- a/engine/src/command/impl/is.rs
+++ b/engine/src/command/impl/is.rs
@@ -11,9 +11,11 @@ impl Dispatch for Is {
             .ok_or_else(|| DispatchError::KeyTypeRequired)?;
         let mut args = req.args(..).ok_or(DispatchError::ArgumentRetrieval)?;
 
-        let all = args.all(|key| match hop.state().key_ref(key) {
-            Some(value) => value.value().kind() == key_type,
-            None => false,
+        let all = args.all(|key| {
+            hop.state()
+                .key_type(key)
+                .map(|k| k == key_type)
+                .unwrap_or(false)
         });
 
         response::write_bool(resp, all);

--- a/engine/src/command/impl/keys.rs
+++ b/engine/src/command/impl/keys.rs
@@ -22,11 +22,14 @@ impl Keys {
 impl Dispatch for Keys {
     fn dispatch(hop: &Hop, req: &Request, resp: &mut Vec<u8>) -> DispatchResult<()> {
         let key = req.key().ok_or(DispatchError::KeyUnspecified)?;
+        let key_type = req
+            .key_type()
+            .or_else(|| hop.state().key_type(key))
+            .unwrap_or(KeyType::Map);
 
-        match req.key_type() {
-            Some(KeyType::Map) => Self::map(hop, key, resp),
-            Some(_) => Err(DispatchError::KeyTypeInvalid),
-            None => Self::map(hop, key, resp),
+        match key_type {
+            KeyType::Map => Self::map(hop, key, resp),
+            _ => Err(DispatchError::KeyTypeInvalid),
         }
     }
 }

--- a/engine/src/command/impl/set.rs
+++ b/engine/src/command/impl/set.rs
@@ -131,12 +131,10 @@ impl Dispatch for Set {
             return Err(DispatchError::ArgumentRetrieval);
         }
 
-        let key_type = req.key_type().unwrap_or_else(|| {
-            hop.state()
-                .key_or_insert_with(key, Value::bytes)
-                .value()
-                .kind()
-        });
+        let key_type = req
+            .key_type()
+            .or_else(|| hop.state().key_type(key))
+            .unwrap_or(KeyType::Bytes);
 
         match key_type {
             KeyType::Bytes => Self::bytes(hop, req, resp, key),

--- a/engine/src/command/impl/type.rs
+++ b/engine/src/command/impl/type.rs
@@ -14,12 +14,12 @@ impl Dispatch for Type {
             return Err(DispatchError::KeyTypeUnexpected);
         }
 
-        let key = hop
+        let key_type = hop
             .state()
-            .key_ref(key)
+            .key_type(key)
             .ok_or_else(|| DispatchError::KeyNonexistent)?;
 
-        response::write_int(resp, key.kind() as i64);
+        response::write_int(resp, key_type as i64);
 
         Ok(())
     }

--- a/engine/src/state/mod.rs
+++ b/engine/src/state/mod.rs
@@ -190,11 +190,28 @@ impl State {
             }
         }
     }
+
+    /// Retrieve the key type of a key's value, if it exists.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use hop_engine::state::{KeyType, State, Value};
+    ///
+    /// let state = State::new();
+    /// assert!(state.key_type(b"foo").is_none());
+    ///
+    /// state.insert(b"foo".to_vec(), Value::Boolean(true));
+    /// assert_eq!(Some(KeyType::Boolean), state.key_type(b"foo"));
+    /// ```
+    pub fn key_type(&self, key: &[u8]) -> Option<KeyType> {
+        self.0.get(key).map(|r| r.value().kind())
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{KeyType, State};
+    use super::{KeyType, State, Value};
     use core::{convert::TryFrom, fmt::Debug, hash::Hash};
     use static_assertions::assert_impl_all;
 
@@ -208,4 +225,20 @@ mod tests {
         TryFrom<u8>
     );
     assert_impl_all!(State: Clone, Debug, Default);
+
+    #[test]
+    fn test_key_type_nonexistent_key() {
+        let state = State::new();
+        assert!(state.key_type(b"foo").is_none());
+    }
+
+    #[test]
+    fn test_key_type_with_key() {
+        let state = State::new();
+        state.insert(b"foo".to_vec(), Value::Bytes([1, 2].to_vec()));
+        assert_eq!(Some(KeyType::Bytes), state.key_type(b"foo"));
+
+        state.insert(b"bar".to_vec(), Value::Integer(123));
+        assert_eq!(Some(KeyType::Integer), state.key_type(b"bar"));
+    }
 }


### PR DESCRIPTION
Add a method to the State, `key_type`, which retrieves the key type of a key if it exists. This simplifies working around a key when you only need the type of it, and reduces the time that a reference to the pair in the state is held.

This also simplifies a lot of code, and fixes some code that was needlessly creating keys that weren't being assigned a (non-empty) value.